### PR TITLE
Delete G-Code File on Octoprint

### DIFF
--- a/docker-compose-developer.yml
+++ b/docker-compose-developer.yml
@@ -1,6 +1,7 @@
 version: '2.4'
 
-x-web-defaults: &web-defaults
+x-web-defaults:
+  &web-defaults
   restart: unless-stopped
   build:
     context: web
@@ -10,13 +11,13 @@ x-web-defaults: &web-defaults
   depends_on:
     - redis
   environment:
-    EMAIL_HOST:     # -> such as 'smtp.gmail.com'
-    EMAIL_HOST_USER:   # -> such as your email address for a Gmail account
-    EMAIL_HOST_PASSWORD:    # -> your email account password
-    EMAIL_PORT: 587  # Check with your email provider to make sure. DO NOT surround it with quotes. Otherwise email won't be sent!
-    EMAIL_USE_TLS: 'True' # Change it to 'False' if your email provider doesn't use TLS, which is uncommon
-    DEFAULT_FROM_EMAIL: 'changeme@example.com'
-    DEBUG: 'False'    # Don't set DEBUG to True, otherwise the static files will be cached in browser until hard-refresh
+    EMAIL_HOST: "smtp.gmail.com"
+    EMAIL_HOST_USER: "something@gmail.com"
+    EMAIL_HOST_PASSWORD: "abc123"
+    EMAIL_PORT: 587
+    EMAIL_USE_TLS: 'True'
+    DEFAULT_FROM_EMAIL: 'tsd@local'
+    DEBUG: 'False' # Don't set DEBUG to True, otherwise the static files will be cached in browser until hard-refresh
     SITE_USES_HTTPS: 'False' # set it to 'True' if https is set up
     SITE_IS_PUBLIC: 'False' # set it to 'True' if the site configured in django admin is accessible from the internet
     SOCIAL_LOGIN: 'False'
@@ -24,10 +25,9 @@ x-web-defaults: &web-defaults
     DATABASE_URL: 'sqlite:////app/db.sqlite3'
     INTERNAL_MEDIA_HOST: 'http://web:3334'
     ML_API_HOST: 'http://ml_api:3333'
-    ACCOUNT_ALLOW_SIGN_UP: 'False'  # -> set to 'True' if you want to open sign up form
+    ACCOUNT_ALLOW_SIGN_UP: 'False' # -> set to 'True' if you want to open sign up form
     WEBPACK_LOADER_ENABLED:
     OCTOPRINT_TUNNEL_PORT_RANGE: '${OCTOPRINT_TUNNEL_PORT_RANGE-15853-15873}'
-
     #### Optional env vars below this line ###
     #TWILIO_ACCOUNT_SID: https://django-twilio.readthedocs.io/en/latest/settings.html for how to find and set the TWILIO_XXX vars
     #TWILIO_AUTH_TOKEN:
@@ -44,21 +44,21 @@ services:
     build:
       context: ml_api
     environment:
-        DEBUG: 'True'
-        FLASK_APP: 'server.py'
-        #ML_API_TOKEN:
-        #HAS_GPU: 'False'
+      DEBUG: 'True'
+      FLASK_APP: 'server.py'
+      #ML_API_TOKEN:
+      #HAS_GPU: 'False'
     command: bash -c "gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi"
 
   web:
     <<: *web-defaults
     hostname: web
     ports:
-      - "3334:3334"
+      - "3000:3334"
       - "${OCTOPRINT_TUNNEL_PORT_RANGE-15853-15873}:3334"
     depends_on:
       - ml_api
-    command: sh -c "python manage.py collectstatic -v 2 --noinput && python manage.py migrate && python manage.py runserver --nostatic --noreload 0.0.0.0:3334"
+    command: sh -c "python manage.py collectstatic -v 2 --noinput && python manage.py migrate && python manage.py runserver --nostatic 0.0.0.0:3334"
 
   tasks:
     <<: *web-defaults
@@ -68,3 +68,19 @@ services:
   redis:
     restart: unless-stopped
     image: redis:5.0-alpine
+
+  # octoprint:
+  #   image: octoprint/octoprint
+  #   restart: unless-stopped
+  #   ports:
+  #     - 8080:80
+  #   volumes:
+  #     - octoprint:/octoprint
+
+volumes:
+  octoprint:
+
+networks: 
+  default: 
+    external: 
+      name: tsd_overlay

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '2.4'
 
-x-web-defaults: &web-defaults
+x-web-defaults:
+  &web-defaults
   restart: unless-stopped
   build:
     context: web
@@ -10,13 +11,13 @@ x-web-defaults: &web-defaults
   depends_on:
     - redis
   environment:
-    EMAIL_HOST:     # -> such as 'smtp.gmail.com'
-    EMAIL_HOST_USER:   # -> such as your email address for a Gmail account
-    EMAIL_HOST_PASSWORD:    # -> your email account password
-    EMAIL_PORT: 587  # Check with your email provider to make sure. DO NOT surround it with quotes. Otherwise email won't be sent!
-    EMAIL_USE_TLS: 'True' # Change it to 'False' if your email provider doesn't use TLS, which is uncommon
-    DEFAULT_FROM_EMAIL: 'changeme@example.com'
-    DEBUG: 'False'    # Don't set DEBUG to True, otherwise the static files will be cached in browser until hard-refresh
+    EMAIL_HOST: "smtp.gmail.com"
+    EMAIL_HOST_USER: "something@gmail.com"
+    EMAIL_HOST_PASSWORD: "abc123"
+    EMAIL_PORT: 587
+    EMAIL_USE_TLS: 'True'
+    DEFAULT_FROM_EMAIL: 'tsd@local'
+    DEBUG: 'False' # Don't set DEBUG to True, otherwise the static files will be cached in browser until hard-refresh
     SITE_USES_HTTPS: 'False' # set it to 'True' if https is set up
     SITE_IS_PUBLIC: 'False' # set it to 'True' if the site configured in django admin is accessible from the internet
     SOCIAL_LOGIN: 'False'
@@ -24,10 +25,9 @@ x-web-defaults: &web-defaults
     DATABASE_URL: 'sqlite:////app/db.sqlite3'
     INTERNAL_MEDIA_HOST: 'http://web:3334'
     ML_API_HOST: 'http://ml_api:3333'
-    ACCOUNT_ALLOW_SIGN_UP: 'False'  # -> set to 'True' if you want to open sign up form
+    ACCOUNT_ALLOW_SIGN_UP: 'False' # -> set to 'True' if you want to open sign up form
     WEBPACK_LOADER_ENABLED:
     OCTOPRINT_TUNNEL_PORT_RANGE: '${OCTOPRINT_TUNNEL_PORT_RANGE-15853-15873}'
-
     #### Optional env vars below this line ###
     #TWILIO_ACCOUNT_SID: https://django-twilio.readthedocs.io/en/latest/settings.html for how to find and set the TWILIO_XXX vars
     #TWILIO_AUTH_TOKEN:
@@ -44,21 +44,21 @@ services:
     build:
       context: ml_api
     environment:
-        DEBUG: 'True'
-        FLASK_APP: 'server.py'
-        #ML_API_TOKEN:
-        #HAS_GPU: 'False'
+      DEBUG: 'True'
+      FLASK_APP: 'server.py'
+      #ML_API_TOKEN:
+      #HAS_GPU: 'False'
     command: bash -c "gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi"
 
   web:
     <<: *web-defaults
     hostname: web
     ports:
-      - "3334:3334"
+      - "3000:3334"
       - "${OCTOPRINT_TUNNEL_PORT_RANGE-15853-15873}:3334"
     depends_on:
       - ml_api
-    command: sh -c "python manage.py collectstatic -v 2 --noinput && python manage.py migrate && python manage.py runserver --nostatic --noreload 0.0.0.0:3334"
+    command: sh -c "python manage.py collectstatic -v 2 --noinput && python manage.py migrate && python manage.py runserver --nostatic 0.0.0.0:3334"
 
   tasks:
     <<: *web-defaults
@@ -68,3 +68,19 @@ services:
   redis:
     restart: unless-stopped
     image: redis:5.0-alpine
+
+  # octoprint:
+  #   image: octoprint/octoprint
+  #   restart: unless-stopped
+  #   ports:
+  #     - 8080:80
+  #   volumes:
+  #     - octoprint:/octoprint
+
+volumes:
+  octoprint:
+
+networks: 
+  default: 
+    external: 
+      name: tsd_overlay

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -1,0 +1,70 @@
+# Developer Guide
+
+How to set up a simple development environment. 
+
+## Docker Compose Modifications
+
+To have a simple and easy octoprint with a virtual server, add the following to the docker-compose file:
+
+```
+  octoprint:
+    image: octoprint/octoprint
+    restart: unless-stopped
+    ports:
+      - 8080:80
+    volumes:
+      - octoprint:/octoprint
+```
+
+Also, in the "web" servive, modify the "command" entry to remove "-noreload".  This gets the web server
+to reload itself whenever it detects a python file is updated.
+
+## Getting Started
+
+To run TSD in developer mode:
+
+1. ```make build-images```
+1. ```make vue-live```
+1. Open another terminal, and run ```make frontdev-up```
+
+After that:
+
+1. Log into TSD Admin and set it up as you would normally.
+1. Log into octoprint, set it up to allow a virtual 3d printer.  
+1. Install the TSD plugin.
+1. Connect TSD Plugin to the dev instance of TSD.
+
+Optional Steps:
+
+If you want to run two instances of TSD, then make two different folders as shown below.
+
+```
+<parent_folder>/TheSpaghettiDetective
+<parent_folder>/TheSpaghettiDetective_develop
+```
+
+Run, the first TSD instance normally. Don't change anything. In the second folder with "_develop", simply
+change the ports in the docker compose file to be something other than 3334.  Afterward, start up the 
+develop TSD beside the regular one.  
+
+## Developing at the same time as Octoprint TSD Plugin
+
+Both repositories will have to be put on an overlay network.  
+
+Add the following to each docker-compose.yml file. This will set the default network to an
+attachable overlay network for each service.  
+
+```
+networks: 
+  default: 
+    external: 
+      name: tsd_overlay
+```
+
+Run this command:
+
+```
+docker network create -d overlay --attachable tsd_overlay
+```
+
+Then, run the start up functions for each repository.

--- a/web/app/urls.py
+++ b/web/app/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('prints/shot-feedback/<pk>/', web_views.print_shot_feedback),
     path('gcodes/', web_views.gcodes),
     path('gcodes/upload/', web_views.upload_gcode_file,),
+    path('gcodes/remove/', web_views.remove_gcode_file,),
     path('hc/', web_views.health_check,),
     path('publictimelapses/', RedirectView.as_view(url='/ent_pub/publictimelapses/', permanent=True), name='publictimelapse_list'),
 

--- a/web/app/views/web_views.py
+++ b/web/app/views/web_views.py
@@ -1,6 +1,7 @@
 import os
 from binascii import hexlify
 import re
+import json
 
 from django.shortcuts import render, redirect
 from django.views import View
@@ -188,6 +189,19 @@ def upload_gcode_file(request):
         _, ext_url = save_file_obj(f'{request.user.id}/{gcode_file.id}', request.FILES['file'], settings.GCODE_CONTAINER)
         gcode_file.url = ext_url
         gcode_file.save()
+
+        return JsonResponse(dict(status='Ok'))
+    else:
+        return render(request, 'upload_print.html')
+
+@login_required
+def remove_gcode_file(request):
+    if request.method == 'POST':
+        
+        body_unicode = request.body.decode('utf-8')
+        body_data = json.loads(body_unicode)
+
+        print(body_data)
 
         return JsonResponse(dict(status='Ok'))
     else:

--- a/web/frontend/src/lib/printer_comm.js
+++ b/web/frontend/src/lib/printer_comm.js
@@ -113,6 +113,9 @@ export default function PrinterComm(printerId, wsUri, onPrinterUpdateReceived, o
   }
 
   self.passThruToPrinter = function(msg, callback) {
+    console.log('**************************************************')
+    console.log(msg)
+    console.log('**************************************************')
     if (self.canSend()) {
       var refId = Math.random().toString()
       assign(msg, {ref: refId})


### PR DESCRIPTION
Call back added should trigger a web socket connection back to
octoprint TSD plugin to call delete function.

There is a "sister" update in the TSD Octoprint plugin repo, and the PR link is noted below.

Work In Progress. Issues to figure out:
* When clicking the delete button, need to figure out how to get a web connection to each printer in GCodePage.vue. Right now, the connection is null because I don't have a printer id.

Questions:
* When deleting GCode, should it be deleted on all printers? Or, a specfic printer? Can't assume only uploaded to one.


Please Note: Started work off of "release" branch because "master" was not working at the time. At some point, will need to change the base of this branch over to master.

Relates to: https://github.com/TheSpaghettiDetective/OctoPrint-TheSpaghettiDetective/pull/159
Relates to: https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/601