### PR TITLE
Update telegram guide

### DIFF
--- a/docs/telegram_guide.md
+++ b/docs/telegram_guide.md
@@ -1,5 +1,6 @@
 # Telegram Setup Guide
 
+## Link using Telegram Login Widget
 My Base: Fresh Install Ubuntu 20.04.
 
 You need to open a terminal with your device. I am doing this via SSH (I'm using Putty on windows).
@@ -86,3 +87,23 @@ Go in preferences and connect to Telegram.
 RESULTS
 
 ![Results](img/telegram/result.JPG)
+
+
+### Link without Telegram Login Widget
+
+When running in local network you don't need to setup specific domain and go through telegram login widget.
+You can register any telegram chat where you want bot sending notification, it can be private or group chat
+
+1. Obtain bot api key form bot father (previous section in step 7).
+2. Set bot api key in docker-compose.yml (previous section in step 8).
+3. Create chat group or chat with bot directly in the telegram. Write a message that bot can process line "/test".
+4. Go to `https://api.telegram.org/bot<chat id>/getUpdates` and find the channel id where you want bot to send messages
+5. In Obico go to Preferences->Notifications->Telegram
+6. Open developer console in your browser
+7. Type and send
+```
+window.onTelegramAuth({
+   id: <chat id>
+})
+```
+7. Telegram is linked, test it with "Test Telegram Notification" button


### PR DESCRIPTION
Telegram bot can be registered without need of https domain or using looptools. I have been using this method in my local setup for a few months and someone might find it useful too.