### PR TITLE
Avahi script for Jetson & Doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Upon fresh installation, the Obico Server can only work on the localhost. You wi
 
 ## Obtain server's IP address
 
-[Recommended Read: Connecting to your server with a .local address](website\docs\server-guides\configure.md)
+[Recommended Read: Connecting to your server with a .local address](https://www.obico.io/docs/server-guides/configure/)
 
 This refers to the LAN IP address that has been given to the computer that the Obico server is running on. 
 - If you are on Linux: Open the wifi settings and select "settings" for the network your device is currently connected to. Look for the IPv4 value. 

--- a/scripts/avahi_setup_jetson.sh
+++ b/scripts/avahi_setup_jetson.sh
@@ -1,0 +1,52 @@
+#!/bin/bash -e
+echo "Setting up Avahi and setup tools..."
+
+sudo apt-get install -y avahi-daemon
+
+# https://manpages.ubuntu.com/manpages/trusty/man5/avahi-daemon.conf.5.html
+# Enables some settings that are good and useful to have actived
+avahi_modify() { # Usage: avahi_modify KEY VALUE
+	# first -e removes comment # if it exists. Second -e sets the value to whatever was passed. 
+	sudo sed -i -e "/$1/s/^#//g" -e "s/\($1 *= *\).*/\1$2/" /etc/avahi/avahi-daemon.conf
+}
+
+avahi_modify publish-addresses yes
+avahi_modify publish-hinfo yes
+avahi_modify publish-workstation yes
+avahi_modify publish-domain yes
+
+hostname=$(hostname)
+
+echo "Avahi Succesfully set up"
+echo -e "Your computer is accesible at ${hostname}.local"
+
+while true; do
+	printf "Would you like to change the address hostname it is accesible at obico.local?\nYes/No (yN)\tDetails (d) "
+	read -p " " ynd
+
+	case $ynd in
+		[Yy]* ) avahi_modify host-name obico; hostname="obico"; printf "\nHostname set to Obico.\n"; break;;
+		[Nn]* ) break;;
+		[Dd]* ) echo "Changing the Avahi hostname to Obico will change the address your server is currently accesible from. This will not have any other effect on your computer. This can easily be manually rverted or changed back later on if you choose.";;
+		* ) echo "Please answer yes for obico, or no to leave hostname as is";;
+	esac
+done
+
+sudo systemctl enable avahi-daemon
+sudo systemctl start avahi-daemon
+
+sleep 5
+# Test pings to ensure that the address is setup. In my experience, Avahi sets up pretty quickly, so more than 5 seconds is unnecesary
+ping -q -c5 $hostname.local > /dev/null
+if [ $? -eq 0 ]; then
+	sudo systemctl restart avahi-daemon
+fi
+
+sleep 5
+
+ping -q -c5 $hostname.local > /dev/null
+if [ $? -eq 0 ]; then
+ 	echo -e "Odd, Avahi is still not running. Status of avahi can be found with the command \"sudo systemctl status avahi-daemon\""
+else
+	echo -e "Avahi is now setup. Server is accessible at $hostname.local"
+fi

--- a/scripts/avahi_setup_jetson.sh
+++ b/scripts/avahi_setup_jetson.sh
@@ -6,8 +6,8 @@ sudo apt-get install -y avahi-daemon
 # https://manpages.ubuntu.com/manpages/trusty/man5/avahi-daemon.conf.5.html
 # Enables some settings that are good and useful to have actived
 avahi_modify() { # Usage: avahi_modify KEY VALUE
-	# first -e removes comment # if it exists. Second -e sets the value to whatever was passed. 
-	sudo sed -i -e "/$1/s/^#//g" -e "s/\($1 *= *\).*/\1$2/" /etc/avahi/avahi-daemon.conf
+    # first -e removes comment # if it exists. Second -e sets the value to whatever was passed. 
+    sudo sed -i -e "/$1/s/^#//g" -e "s/\($1 *= *\).*/\1$2/" /etc/avahi/avahi-daemon.conf
 }
 
 avahi_modify publish-addresses yes
@@ -21,15 +21,15 @@ echo "Avahi Succesfully set up"
 echo -e "Your computer is accesible at ${hostname}.local"
 
 while true; do
-	printf "Would you like to change the address hostname it is accesible at obico.local?\nYes/No (yN)\tDetails (d) "
-	read -p " " ynd
+    printf "Would you like to change the address hostname it is accesible at obico.local?\nYes/No (yN)\tDetails (d) "
+    read -p " " ynd
 
-	case $ynd in
-		[Yy]* ) avahi_modify host-name obico; hostname="obico"; printf "\nHostname set to Obico.\n"; break;;
-		[Nn]* ) break;;
-		[Dd]* ) echo "Changing the Avahi hostname to Obico will change the address your server is currently accesible from. This will not have any other effect on your computer. This can easily be manually rverted or changed back later on if you choose.";;
-		* ) echo "Please answer yes for obico, or no to leave hostname as is";;
-	esac
+    case $ynd in
+        [Yy]* ) avahi_modify host-name obico; hostname="obico"; printf "\nHostname set to Obico.\n"; break;;
+        [Nn]* ) break;;
+        [Dd]* ) echo "Changing the Avahi hostname to Obico will change the address your server is currently accesible from. This will not have any other effect on your computer. This can easily be manually rverted or changed back later on if you choose.";;
+        * ) echo "Please answer yes for obico, or no to leave hostname as is";;
+    esac
 done
 
 sudo systemctl enable avahi-daemon
@@ -39,14 +39,14 @@ sleep 5
 # Test pings to ensure that the address is setup. In my experience, Avahi sets up pretty quickly, so more than 5 seconds is unnecesary
 ping -q -c5 $hostname.local > /dev/null
 if [ $? -eq 0 ]; then
-	sudo systemctl restart avahi-daemon
+    sudo systemctl restart avahi-daemon
 fi
 
 sleep 5
 
 ping -q -c5 $hostname.local > /dev/null
 if [ $? -eq 0 ]; then
- 	echo -e "Odd, Avahi is still not running. Status of avahi can be found with the command \"sudo systemctl status avahi-daemon\""
+     echo -e "Odd, Avahi is still not running. Status of avahi can be found with the command \"sudo systemctl status avahi-daemon\""
 else
-	echo -e "Avahi is now setup. Server is accessible at $hostname.local"
+    echo -e "Avahi is now setup. Server is accessible at $hostname.local"
 fi

--- a/scripts/install_on_jetson.sh
+++ b/scripts/install_on_jetson.sh
@@ -21,3 +21,15 @@ EOT
 sudo docker-compose up -d
 
 sudo systemctl enable docker
+
+while true; do
+    printf "Would you like to change the address hostname it is accesible at obico.local?\nYes/No (yN)\tDetails (d) "
+	read -p " " ynd
+    
+    case $ynd in
+        [Yy]* ) sudo ./avahi_setup_jetson.sh; break;;
+        [Nn]* ) break;;
+        [Dd]* ) echo "Read More Here: https://www.obico.io/docs/server-guides/configure/";;
+        * ) echo "Please answer yes or no.";;
+    esac
+done

--- a/scripts/install_on_jetson.sh
+++ b/scripts/install_on_jetson.sh
@@ -24,7 +24,7 @@ sudo systemctl enable docker
 
 while true; do
     printf "Would you like to change the address hostname it is accesible at obico.local?\nYes/No (yN)\tDetails (d) "
-	read -p " " ynd
+    read -p " " ynd
     
     case $ynd in
         [Yy]* ) sudo ./avahi_setup_jetson.sh; break;;

--- a/website/docs/server-guides/configure.md
+++ b/website/docs/server-guides/configure.md
@@ -26,15 +26,21 @@ Similarly to how one can connect to octopi with octopi.local instead of an IP ad
 Doing this on a device that is already running software with similar functionality(ex. Homebridge) **may** cause issues. If a conflict does occur, it will not be fatal to either program or computer. This warning can mostly be ignored if this tool is new to you.
 :::
 
-- If you are on Linux, run `sudo apt install avahi-daemon`
-- If you are on Windows, install [iTunes](https://www.apple.com/itunes/). This may sound odd, but this is the best and safest way to do this on Windows. The reason this must be done is because the latest version of the software we need(Bonjour) can only downloaded bundled with iTunes.
+- If you are on Windows, install [iTunes]([url](https://www.apple.com/itunes/)). This may sound odd, but this is the best and safest way to do this on Windows. The reason this must be done is because the latest version of the software we need(Bonjour) can only downloaded bundled with iTunes.
 - If you are on Mac, you do not need to do anything. Mac already has this set up by default.
+- If you are on Linux, most distros come with `avahi-daemon` installed(ubuntu, debian, arch, redhat). Instructions on installation/update for `avahi-daemon` for your distro can be found online.
+  - To enable Avahi, run `sudo systemctl enable avahi-daemon && sudo systemctl start avahi-daemon`. You are now done.
+  - Although optional, we reccomend you change some settings in yoru config file. 
+    - Located in `/etc/avahi/avahi-daemon.conf`, uncomment(if needed, done by removing the `#`) and set `publish-addresses`, `publish-hinfo`, `publish-workstation`, `publish-domain` all equal to `yes`. Do **not** include spaces before and after the equal sign
+    - More optionally, you can change the hostname of the service by uncomenting and setting `hostname` to whatever you would like.
+    - you can now restart avahi by runnning `sudo systemctl restart avahi-daemon`
+    - More information on this can be found in the [docs](https://manpages.ubuntu.com/manpages/trusty/man5/avahi-daemon.conf.5.html).
 
 You can find your hostname by typing `hostname` into your terminal, regardless of OS.
 
 You can now connect to your server with `your_host_name.local:3334`. Conveniently, your host name is not case sensitive. 
 
-To reiterate, you can connect to your server with either your IPv4 address or .local address. If you choose to use a .local address, you may assume `your_server_ip` to be interchangeable with your .local address. You can use it not only as a URL, but also for SSH and any time you may need to connect directly to that device. 
+To reiterate, you can connect to your server with either `your_server_ip:3334` or `your_host_name.local:3334`. If you choose to use a .local address, you may assume `your_server_ip` to be interchangeable with your .local address. You can use it not only as a URL, but also for SSH and as a general replacement for the ip address. 
 #### Login as Django admin
 
 1. Open Django admin page at `http://your_server_ip:3334/admin/`.


### PR DESCRIPTION
Added a script that installs and sets up Avahi on the Jetson at server setup. User can opt out.

Also improved configuration docs for linux as avahi needs some setup to be good.

Fixed broken link in readme to avahi setup.