### PR TITLE
Admin site ip whitelist feature

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -3,6 +3,7 @@ import dj_database_url
 import re
 import os
 import sentry_sdk
+import json
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -98,6 +99,7 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'app.middleware.octoprint_tunnelv2',
+    'app.middleware.check_admin_ip_whitelist',
 ]
 
 ROOT_URLCONF = 'config.urls'
@@ -413,3 +415,5 @@ WELL_KNOWN_PATH = None
 NOTIFICATION_PLUGIN_DIRS = [
     os.path.join(BASE_DIR, 'notifications/plugins'),
 ]
+
+ADMIN_IP_WHITELIST = json.loads(os.environ.get('ADMIN_IP_WHITELIST') or '[]')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-web-defaults: &web-defaults
     EMAIL_USE_TLS: '${EMAIL_USE_TLS-True}'
     DEFAULT_FROM_EMAIL: '${DEFAULT_FROM_EMAIL-changeme@example.com}'
     DEBUG: '${DEBUG-False}'    # Don't set DEBUG to True unless you know what you are doing. Otherwise the static files will be cached in browser until hard-refresh
+    ADMIN_IP_WHITELIST: '${ADMIN_IP_WHITELIST-}'
     SITE_USES_HTTPS: '${SITE_USES_HTTPS-False}'
     SITE_IS_PUBLIC: '${SITE_IS_PUBLIC-False}'
     SOCIAL_LOGIN: '${SOCIAL_LOGIN-False}'


### PR DESCRIPTION
When enabled, /admin/ is accessible only from ip-s whitelisted in django
settings.

ADMIN_IP_WHITELIST env var is expected to be a json list of ips, when
set (like '["1.2.3.4", "5.6.7.8"]').