### PR TITLE
PrintDone handling fix (OctoKlipper)

### DIFF
--- a/backend/api/octoprint_messages.py
+++ b/backend/api/octoprint_messages.py
@@ -69,7 +69,9 @@ def process_octoprint_status_with_ts(op_status, printer):
         op_data.get('job', {}).get('file', {}).get('name') or
         op_event.get('data', {}).get('name')
     )
-    if not current_filename:
+
+    has_print_but_no_ts_in_status = printer.current_print is not None and print_ts == -1
+    if not current_filename and not has_print_but_no_ts_in_status:
         return
     printer.update_current_print(current_filename, print_ts)
     if not printer.current_print:

--- a/backend/api/octoprint_messages.py
+++ b/backend/api/octoprint_messages.py
@@ -64,7 +64,11 @@ def process_octoprint_status_with_ts(op_status, printer):
     op_event = op_status.get('octoprint_event', {})
     op_data = op_status.get('octoprint_data', {})
     print_ts = op_status.get('current_print_ts')
-    current_filename = op_event.get('name') or op_data.get('job', {}).get('file', {}).get('name')
+    current_filename = (
+        op_event.get('name') or
+        op_data.get('job', {}).get('file', {}).get('name') or
+        op_event.get('data', {}).get('name')
+    )
     if not current_filename:
         return
     printer.update_current_print(current_filename, print_ts)


### PR DESCRIPTION
Job data is empty in status updates after PrintDone when using octoklipper.
Filename of job might be under data key in event metadata. 