### PR TITLE
Modify .env instead of compose file

### DIFF
--- a/website/docs/server-guides/advanced/reverse-proxy.md
+++ b/website/docs/server-guides/advanced/reverse-proxy.md
@@ -30,8 +30,7 @@ The "Domain name" needs to be set to `reverse_proxy_ip:reverse_proxy_port`. The 
 1. If you haven't already, make a copy of `dotenv.example` and rename it as `.env` in the `obico-server` directory.
 2. Open `.env` using your favorite editor.
 3. Find `SITE_USES_HTTPS=False` and replace it with `SITE_USES_HTTPS=True`.
-
-2. Restart the server: `docker-compose restart`.
+4. Restart the server: `docker-compose restart`.
 
 ## NGINX {#nginx}
 

--- a/website/docs/server-guides/advanced/reverse-proxy.md
+++ b/website/docs/server-guides/advanced/reverse-proxy.md
@@ -27,7 +27,9 @@ The "Domain name" needs to be set to `reverse_proxy_ip:reverse_proxy_port`. The 
 
 ## 2. If the reverse proxy is accessed through HTTPS: {#2-if-the-reverse-proxy-is-accessed-through-https}
 
-1. Open `docker-compose.yml`, find `SITE_USES_HTTPS: 'False'` and replace it with `SITE_USES_HTTPS: 'True'`.
+1. If you haven't already, make a copy of `dotenv.example` and rename it as `.env` in the `obico-server` directory.
+2. Open `.env` using your favorite editor.
+3. Find `SITE_USES_HTTPS=False` and replace it with `SITE_USES_HTTPS=True`.
 
 2. Restart the server: `docker-compose restart`.
 


### PR DESCRIPTION
To keep consistency with the [email setup](https://www.obico.io/docs/server-guides/configure/#email-smtp) I think it would be better to set all parameters in the `.env` file instead of telling the user to modify `docker-compose.yml` (arguably more sensitive to errors)