### PR TITLE
Fixes for consumer error reporting

### DIFF
--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -157,11 +157,6 @@ class SharedWebConsumer(WebConsumer):
         ).printer
 
     @newrelic.agent.background_task()
-    @close_on_error
-    def connect(self):
-        pass
-
-    @newrelic.agent.background_task()
     @report_error
     def receive_json(self, data, **kwargs):
         # we don't expect frontend sending anything important,

--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -196,6 +196,7 @@ class OctoPrintConsumer(WebsocketConsumer):
 
     @newrelic.agent.background_task()
     @close_on_error
+    @close_on_error(exc_class=Printer.DoesNotExist, sentry=False)
     def connect(self):
         self.connected_at = time.time()
         self.printer = None

--- a/backend/api/consumers.py
+++ b/backend/api/consumers.py
@@ -438,6 +438,7 @@ class OctoprintTunnelWebConsumer(WebsocketConsumer):
 
     @newrelic.agent.background_task()
     @close_on_error
+    @close_on_error(exc_class=Printer.DoesNotExist, sentry=False)
     def connect(self):
         self.user, self.printer = None, None
         # Exception for un-authenticated or un-authorized access


### PR DESCRIPTION
Removed one connect method override added by mistake, this fixes shared printers.

Added additional @close_on_error rule.