### PR TITLE
Serve web container with daphne

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - "3334:3334"
     depends_on:
       - ml_api
-    command: sh -c 'python manage.py migrate && python manage.py collectstatic -v 2 --noinput && python manage.py runserver --nostatic --noreload 0.0.0.0:3334'
+    command: sh -c 'python manage.py migrate && python manage.py collectstatic -v 2 --noinput && daphne --bind 0.0.0.0 --port 3334 config.asgi:application'
 
   tasks:
     <<: *web-defaults


### PR DESCRIPTION
Hello! I've been using Obico for a while and love it.

I was taking a look at the selfhosted stack and noticed the web container is being served with `python manage.py runserver`, which should not be used in production. According to the [Django docs](https://docs.djangoproject.com/en/4.1/ref/django-admin/#runserver):

> DO NOT USE THIS SERVER IN A PRODUCTION SETTING. It has not gone through security audits or performance tests. (And that’s how it’s gonna stay. We’re in the business of making web frameworks, not web servers, so improving this server to be able to handle a production environment is outside the scope of Django.)

Gunicorn won't work due to the websockets requirement, but Daphne has been working well for me.

Feel free to close this if there's a benefit to the built-in server that I missed.

