### PR TITLE
Fixed missing map files issue

### DIFF
--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,52 @@
+import django
+from whitenoise.storage import CompressedManifestStaticFilesStorage, MissingFileError
+
+
+class CustomCompressedManifestStaticFilesStorage(CompressedManifestStaticFilesStorage):
+    if django.VERSION < (4, 0):
+        patterns = CompressedManifestStaticFilesStorage.patterns + (
+            (
+                "*.js",
+                (
+                    (
+                        r"(?m)^(//# (?-i:sourceMappingURL)=(.*))$",
+                        "//# sourceMappingURL=%s",
+                    ),
+                ),
+            ),
+            (
+                "*.css",
+                (
+                    (
+                        r"(?m)^(/\*#[ \t](?-i:sourceMappingURL)=(.*)[ \t]*\*/)$",
+                        "/*# sourceMappingURL=%s */",
+                    ),
+                ),
+            ),
+        )
+    elif django.VERSION < (4, 1):
+        # Django 4.0 switched to named patterns
+        patterns = CompressedManifestStaticFilesStorage.patterns + (
+            (
+                "*.css",
+                (
+                    (
+                        r"(?m)^(?P<matched>/\*#[ \t](?-i:sourceMappingURL)=(?P<url>.*)[ \t]*\*/)$",
+                        "/*# sourceMappingURL=%(url)s */",
+                    ),
+                ),
+            ),
+        )
+    else:
+        raise AssertionError(
+            "The above backported custom patterns are no longer required."
+        )
+
+    def post_process(self, *args, **kwargs):
+        for name, hashed_name, processed in super().post_process(*args, **kwargs):
+            import logging
+            if isinstance(processed, MissingFileError) and name + ".map" in str(processed):
+                logging.error(f"Cannot post-process map file for {name}")
+                continue
+
+            yield name, hashed_name, processed

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -234,7 +234,7 @@ X_FRAME_OPTIONS = 'SAMEORIGIN'
 
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static_build')
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'app.storage.CustomCompressedManifestStaticFilesStorage'
 STATICFILES_DIRS = [
     os.path.join(BASE_DIR, '../frontend/static'),
     os.path.join(BASE_DIR, '../frontend/builds'),


### PR DESCRIPTION
Original idea:

https://adamj.eu/tech/2022/01/26/django-and-source-maps/#backport-to-the-future

I made it to ignore exceptions of missing map files in post_process method.