### PR TITLE
Adding another method to run obico-server using prebuilt images in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git clone -b release https://github.com/TheSpaghettiDetective/obico-server.git
 4. There is no step 4. This is how easy it is to get Obico up and running (thanks to Docker and Docker-compose).
 
 5. Alternatively, if the procedure above does not work for you or you rather like to build your images manually, **either**:
-    - Run the provided bash script which does the above steps for you automatically with `cd /obico-server; chmod u+x build-and-start-obico.sh;./build-and-start-obico.sh`
+    - Run the provided bash script which does the above steps for you automatically with `cd /obico-server; chmod u+x build-and-start-obico.sh; ./build-and-start-obico.sh`
     - Build the containers manually, naming them "obico_ml_api" and "obico_backend", and then simply run: `cd obico-server; docker-compose -f docker-compose-prebuilt.yml up -d`
 
 Open "http://localhost:3334" on the same computer. Voila - your self-hosted Obico Server is now up and running!

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ git clone -b release https://github.com/TheSpaghettiDetective/obico-server.git
 
 4. There is no step 4. This is how easy it is to get Obico up and running (thanks to Docker and Docker-compose).
 
+5. Alternatively, if the procedure above does not work for you or you rather like to build your images manually, **either**:
+    - Run the provided bash script which does the above steps for you automatically with `cd /obico-server; chmod u+x build-and-start-obico.sh;./build-and-start-obico.sh`
+    - Build the containers manually, naming them "obico_ml_api" and "obico_backend", and then simply run: `cd obico-server; docker-compose -f docker-compose-prebuilt.yml up -d`
+
 Open "http://localhost:3334" on the same computer. Voila - your self-hosted Obico Server is now up and running!
 
 ![Login page](website/static/img/server-guides/login-page.png)

--- a/build-and-start-obico.sh
+++ b/build-and-start-obico.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+
+## This bash script will 
+## 1) Build the container images necessary to run the obico server for the architecture the script is running on
+## 2) Run obico-server with the docker-compose-prebuilt.yml uses the previously created container images.
+
+## Defining colors for colored echo output and corresponding functions
+green="\e[0;92m"
+red="\e[0;91m"
+reset="\e[0m"
+
+echo_green() {
+    echo -e "${green}$1${reset}"
+} 
+echo_red() {
+    echo -e "${red}$1${reset}"
+} 
+
+echo "Starting building process..."
+to_build="backend ml_api"
+for name in $to_build; do 
+    echo_green "Building obico_$name image"
+    pushd "$name" || exit 1
+    docker build -t "obico_$name" . && echo_green "Building obico_$name successful" || echo_red "Error while building obico_$name"
+    popd ... || return
+done
+
+while true; do
+    read -rp "Do you wish to start obico-server now? Entering \"y\" will run docker-compose up (y/n)" yn
+    case $yn in 
+        [yY] ) docker-compose -f docker-compose-prebuilt.yml up -d;
+            break;;
+        [nN] ) echo -e "\nYou can start the obico-server by using \"docker-compose -f docker-compose-prebuilt.yml up -d \" from within the obico-server repository";
+            break;;
+        * ) echo_red "Please enter (y/n)";;
+    esac
+done

--- a/docker-compose-prebuilt.yml
+++ b/docker-compose-prebuilt.yml
@@ -1,0 +1,68 @@
+version: '2.4'
+
+x-web-defaults: &web-defaults
+  restart: unless-stopped
+  image: obico_backend
+  volumes:
+    - ./backend:/app
+    - ./frontend:/frontend
+  depends_on:
+    - redis
+  environment:
+    OCTOPRINT_TUNNEL_PORT_RANGE: '0-0'
+    EMAIL_HOST: '${EMAIL_HOST-}'
+    EMAIL_HOST_USER: '${EMAIL_HOST_USER-}'
+    EMAIL_HOST_PASSWORD: '${EMAIL_HOST_PASSWORD-}'
+    EMAIL_PORT: '${EMAIL_PORT-587}'
+    EMAIL_USE_TLS: '${EMAIL_USE_TLS-True}'
+    DEFAULT_FROM_EMAIL: '${DEFAULT_FROM_EMAIL-changeme@example.com}'
+    DEBUG: '${DEBUG-False}'    # Don't set DEBUG to True unless you know what you are doing. Otherwise the static files will be cached in browser until hard-refresh
+    ADMIN_IP_WHITELIST: '${ADMIN_IP_WHITELIST-}'
+    SITE_USES_HTTPS: '${SITE_USES_HTTPS-False}'
+    SITE_IS_PUBLIC: '${SITE_IS_PUBLIC-False}'
+    SOCIAL_LOGIN: '${SOCIAL_LOGIN-False}'
+    REDIS_URL: '${REDIS_URL-redis://redis:6379}'
+    DATABASE_URL: '${DATABASE_URL-sqlite:////app/db.sqlite3}'
+    INTERNAL_MEDIA_HOST: '${INTERNAL_MEDIA_HOST-http://web:3334}'
+    ML_API_HOST: '${ML_API_HOST-http://ml_api:3333}'
+    ACCOUNT_ALLOW_SIGN_UP: '${ACCOUNT_ALLOW_SIGN_UP-False}'
+    WEBPACK_LOADER_ENABLED: '${WEBPACK_LOADER_ENABLED-False}'
+    TELEGRAM_BOT_TOKEN: '${TELEGRAM_BOT_TOKEN-}'
+    TWILIO_ACCOUNT_SID: '${TWILIO_ACCOUNT_SID-}'
+    TWILIO_AUTH_TOKEN: '${TWILIO_AUTH_TOKEN-}'
+    TWILIO_FROM_NUMBER: '${TWILIO_FROM_NUMBER-}'
+    SENTRY_DSN: '${SENTRY_DSN-}'
+    PUSHOVER_APP_TOKEN: '${PUSHOVER_APP_TOKEN-}'
+    SLACK_CLIENT_ID: '${SLACK_CLIENT_ID-}'
+    SLACK_CLIENT_SECRET: '${SLACK_CLIENT_SECRET-}'
+    VERSION:
+
+services:
+  ml_api:
+    hostname: ml_api
+    restart: unless-stopped
+    image: obico_ml_api
+    environment:
+        DEBUG: 'True'
+        FLASK_APP: 'server.py'
+        #ML_API_TOKEN:
+        #HAS_GPU: 'False'
+    command: bash -c "gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi"
+
+  web:
+    <<: *web-defaults
+    hostname: web
+    ports:
+      - "3334:3334"
+    depends_on:
+      - ml_api
+    command: sh -c 'python manage.py migrate && python manage.py collectstatic -v 2 --noinput && python manage.py runserver --nostatic --noreload 0.0.0.0:3334'
+
+  tasks:
+    <<: *web-defaults
+    hostname: tasks
+    command: sh -c "celery -A config worker --beat -l info -c 2 -Q realtime,celery"
+
+  redis:
+    restart: unless-stopped
+    image: redis:5.0-alpine


### PR DESCRIPTION
I added 

1) A modified docker-compose.yml named docker-compose-prebuilt.yml, which instead of building the images within the docker-compose up command refers to prebuilt images. Those images can be either built
- manually, using default docker build commands
- automated, using the script that is provided within this pull request (tested on Linux that supports bash). The script additionally gives the option to automatically run the obico-server after the images are built successfully.