### PR TITLE
Add target_fps to moonraker examples

### DIFF
--- a/website/docs/user-guides/moonraker-obico/config.md
+++ b/website/docs/user-guides/moonraker-obico/config.md
@@ -32,6 +32,7 @@ disable_video_streaming = False
 #
 # snapshot_url = http://127.0.0.1:8080/?action=snapshot
 # stream_url = http://127.0.0.1:8080/?action=stream
+# target_fps = 25
 # flip_h = False
 # flip_v = False
 # rotate_90 = False
@@ -66,6 +67,7 @@ Set values in this section only when **Obico for Klipper** can't obtain these co
 
 - `snapshot_url`:
 - `stream_url`:
+- `target_fps`:
 - `flip_h`:
 - `flip_v`:
 - `rotate_90`:


### PR DESCRIPTION
To match the config option in the dev branch of moonraker-obico, add references to target_fps in documentation