### PR TITLE
Update link to Jetson Nano sd card image v4.6

### DIFF
--- a/website/docs/server-guides/platform-specific/jetson_guide.md
+++ b/website/docs/server-guides/platform-specific/jetson_guide.md
@@ -17,8 +17,8 @@ TSD private server can only run on Jetson Nano 4GB model. The 2GB model doesn't 
 
 The following software is required before you start installing the server:
 
-- [JetPack 4.5 SDK](https://developer.nvidia.com/jetpack-sdk-45-archive). If you already flashed a different OS on your sd card, you will have to replace it with this one. Slow download of the software from NVIDIA is normal.
-  - **Important:** The last JetPack SDK version this has been tested on is jp45. Newer versions may not work correctly (see [bug](https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/552)). If you successfully run this on a newer version, please send a message to the official discord and mention @LyricPants66133
+- [Jetson Nano SD Card Image v4.6](https://developer.download.nvidia.com/embedded/L4T/r32_Release_v6.1/Jeston_Nano/jetson-nano-jp46-sd-card-image.zip). If you already flashed a different OS on your sd card, you will have to replace it with this one. Slow download of the software from NVIDIA is normal.
+  - **Important:** The last JetPack SDK version this has been tested on is jp46. Newer versions (including 4.6.1) may not work correctly (see [bug](https://github.com/TheSpaghettiDetective/TheSpaghettiDetective/issues/552)). If you successfully run this on a newer version, please send a message to the official discord and mention @LyricPants66133
 - [Flashing Software](https://www.balena.io/etcher/)
 - [SD Card Formatter](https://www.sdcard.org/downloads/formatter/)
 


### PR DESCRIPTION
The current version of the sd card image linked to (4.5) does not match the version the script currently targets (4.6). 4.6.1 also cannot be used (as I painfully found out) because python appears to be upgraded to python3 (and I think the python3-is-python package is installed), so the docker-compose plugin does not get successfully installed and is unusable.

This confused me in multiple ways and I hope this changes helps anyone else setting up a Nano in the future.