### PR TITLE
Added signup view to enable/disable sign up page

### DIFF
--- a/backend/app/urls.py
+++ b/backend/app/urls.py
@@ -9,6 +9,7 @@ from .views import tunnelv2_views
 urlpatterns = [
     path('', web_views.index, name='index'),
     path('accounts/login/', web_views.SocialAccountAwareLoginView.as_view(), name="account_login"),
+    path('accounts/signup/', web_views.SocialAccountAwareSignupView.as_view(), name="account_signup"),
     path('media/<path:file_path>', web_views.serve_jpg_file),  # semi hacky solution to serve image files
     path('printers/', web_views.printers, name='printers'),
     re_path('printers/wizard/(?P<route>([^/]+/)*)$', web_views.new_printer),

--- a/backend/app/views/web_views.py
+++ b/backend/app/views/web_views.py
@@ -17,7 +17,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.clickjacking import xframe_options_exempt
 import requests
 
-from allauth.account.views import LoginView
+from allauth.account.views import LoginView, SignupView
 
 from lib.view_helpers import get_print_or_404, get_printer_or_404, get_paginator, get_template_path
 
@@ -43,6 +43,11 @@ def index(request):
 class SocialAccountAwareLoginView(LoginView):
     form_class = SocialAccountAwareLoginForm
 
+class SocialAccountAwareSignupView(SignupView):
+    def dispatch(self, request, *args, **kwargs):
+        if settings.ACCOUNT_ALLOW_SIGN_UP:
+            return super().dispatch(request, *args, **kwargs)
+        return redirect('/accounts/login/')
 
 @login_required
 def printers(request, template_name='printers.html'):


### PR DESCRIPTION
A view was added to override the allauth SignupView.
This will redirect users to the login page if they attempt to access the signup page when ACCOUNT_ALLOW_SIGN_UP is false. Otherwise it uses the original behaviour

fixes #662