### PR TITLE
Update ops.md

### DIFF
--- a/website/docs/server-guides/ops.md
+++ b/website/docs/server-guides/ops.md
@@ -10,7 +10,7 @@ title: Common tasks for operating self-hosted server
     git pull
     docker compose up --build -d
 ```
-*Note: if you are on linux you will have to run the last line as `sudo` (ex. `sudo docker...`)*
+*Note: if you are on linux you _may_ need to run the last line as `sudo` (ex. `sudo docker...`)*
 
 *Note: you need to use `docker-compose` instead of `docker compose` on older Docker versions*
 
@@ -25,3 +25,13 @@ Although you can simply download the timelapses from either the web interface or
 Path to timelapses:
 
 `obico-server/backend/static_build/media/tsd-timelapses/private/`
+
+## Prune old images
+
+As you upgrade the Obico server containers, old (now unused) versions of these containers will be left behind.  To remove these old images, one can run the following:
+
+```
+docker image prune
+```
+
+*Note: if you are on linux you _may_ need to run the last line as `sudo` (ex. `sudo docker...`)*


### PR DESCRIPTION
For _most_ Linux distributions, if a user is part of the `docker` group, they do not need to use `sudo`. 

Additionally, adding a note about how to clean up older images left behind by upgrades.