### PR TITLE
fix exception in notification plugin stopping further processing

### DIFF
--- a/backend/notifications/tasks.py
+++ b/backend/notifications/tasks.py
@@ -144,3 +144,5 @@ def send_failure_alerts(
             plugin.instance.send_failure_alert(context=context)
         except NotImplementedError:
             pass
+        except Exception:
+            capture_exception()


### PR DESCRIPTION
Hi,
I noticed that I did not get failure notifications via pushover anymore and looked into that.

The reason I found was, that another active plugin threw an exception due to an invalid token. Any further plugins were not called anymore, including pushover in my case.

For the general notifications, all plugin exceptions are handled, but that's not the case for the more important failure notifications.
To mitigate the issue, I added the same kind of error handling for failure notification as for general notifications.

Cheers 