### PR TITLE
Fix broken/deficient media streaming in backend/app/views/web_views.py

### DIFF
--- a/backend/app/views/web_views.py
+++ b/backend/app/views/web_views.py
@@ -2,11 +2,12 @@ import mimetypes
 import os
 from binascii import hexlify
 import re
+from wsgiref.util import FileWrapper
 
 from django.shortcuts import render, redirect
 from django.views import View
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse, JsonResponse, HttpResponseForbidden
+from django.http import HttpResponse, JsonResponse, HttpResponseForbidden, StreamingHttpResponse
 from django.contrib import messages
 from django.urls import reverse
 from django.conf import settings
@@ -244,6 +245,38 @@ def printer_events(request):
 ### Misc ####
 
 # Was surprised to find there is no built-in way in django to serve uploaded files in both debug and production mode
+
+class RangeFileWrapper(object):
+    def __init__(self, filelike, blksize=8192, offset=0, length=None):
+        self.filelike = filelike
+        self.filelike.seek(offset, os.SEEK_SET)
+        self.remaining = length
+        self.blksize = blksize
+
+    def close(self):
+        if hasattr(self.filelike, 'close'):
+            self.filelike.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.remaining is None:
+            # If remaining is None, we're reading the entire file.
+            data = self.filelike.read(self.blksize)
+            if data:
+                return data
+            raise StopIteration()
+        else:
+            if self.remaining <= 0:
+                raise StopIteration()
+            data = self.filelike.read(min(self.remaining, self.blksize))
+            if not data:
+                raise StopIteration()
+            self.remaining -= len(data)
+            return data
+       
+range_re = re.compile(r'bytes\s*=\s*(\d+)\s*-\s*(\d*)', re.I)
 def serve_jpg_file(request, file_path):
     url = HmacSignedUrl(request.get_full_path())
     if not url.is_authorized():
@@ -258,9 +291,31 @@ def serve_jpg_file(request, file_path):
         content_type = "application/octet-stream"
     if not os.path.exists(full_path):
         raise Http404("Requested file does not exist")
-    with open(full_path, 'rb') as fh:
-        return HttpResponse(fh, content_type=content_type)
 
+    fh = open(full_path, 'rb')
+    try:
+        range_header = request.META.get('HTTP_RANGE', '').strip()
+        range_match = range_re.match(range_header)
+        size = os.path.getsize(full_path)
+
+        if range_match:
+            first_byte, last_byte = range_match.groups()
+            first_byte = int(first_byte) if first_byte else 0
+            last_byte = int(last_byte) if last_byte else size - 1
+            if last_byte >= size:
+                last_byte = size - 1
+            length = last_byte - first_byte + 1
+            resp = StreamingHttpResponse(RangeFileWrapper(fh, offset=first_byte, length=length), status=206, content_type=content_type)
+            resp['Content-Length'] = str(length)
+            resp['Content-Range'] = 'bytes %s-%s/%s' % (first_byte, last_byte, size)
+        else:
+            resp = StreamingHttpResponse(FileWrapper(fh), content_type=content_type)
+            resp['Content-Length'] = str(size)
+
+        resp['Accept-Ranges'] = 'bytes'
+        return resp
+    except:
+        pass
 
 # Health check that touches DB and redis
 def health_check(request):


### PR DESCRIPTION
As per ([TheSpaghettiDetective/TSDApp#137](https://github.com/TheSpaghettiDetective/TSDApp/issues/137)), current code in backend/app/views/web_views.py fails to properly implement video streaming -- in particular, it doesn't allow seeking which is required by android mediaplayer used in the Obico mobile app.
I fixed the code to properly implement seeking and streaming adapting a code sample posted on: https://stackoverflow.com/questions/33208849/python-django-streaming-video-mp4-file-using-httpresponse
See the above bug report for more details.
TL;DR summary is:
•	Android mediaplayer (but not exoplayer) do a seek EOF on the media stream and so fail to play timelapses (note: VLC and mplayer have the same problem and can't play the streams when pointed to the media url)
•	The very rudimentary HttpResponse web serving method implemented in the current web_views.py does not allow for seeking (or even real streaming (which probably explains why I have never been able to seek forward/backward in a stream - just pause/resume and rewind to start)
•	Obico cloud works fine since it uses storage.googlesapi.com to properly serve streams
•	Similarly, browsers have no problem downloading and playing the media file as a downloadable file
•	This also explains why the mobile app worked when I hacked it to play a fixed, standard test mp4 file or when I moved the timelapse to my own apache server
•	I suspect that others haven't encountered this problem since they likely use a proxy server (which I do not) which presumablhy 'buffers' the timelapse and allows for seeking (I am just guessing here).
Code has been tested to work with Obic mobile app, Obico web as well as with VLC and mplayer when pointing to the timelapse url's (including digest).
Streaming is more responsive even on web and you can now move forward/backward within the stream using the slider...