### PR TITLE
Fix incorrect bounding box detection drawing

### DIFF
--- a/backend/lib/image.py
+++ b/backend/lib/image.py
@@ -4,7 +4,7 @@ def overlay_detections(img, detections):
     draw = ImageDraw.Draw(img)
     for d in detections:
         (xc, yc, w, h) = map(int, d[2])
-        (x1, y1), (x2, y2) = (xc-w//2,yc-h//2), (xc+w//2,yc+w//2)
+        (x1, y1), (x2, y2) = (xc-w//2,yc-h//2), (xc+w//2,yc+h//2)
         points = (x1, y1), (x2, y1), (x2, y2), (x1, y2), (x1, y1)
         draw.line(points, fill=(0,255,0,255), width=3)
     return img


### PR DESCRIPTION
Minor typo but may have noticeable implications in certain situations.

Before:
![obico_before](https://github.com/TheSpaghettiDetective/obico-server/assets/1480252/1d6f926f-0da5-4d4c-bcd0-5116bc63b7fb)

After
![obico_after](https://github.com/TheSpaghettiDetective/obico-server/assets/1480252/70811b40-6fc8-49aa-a9d3-af21b0eef62f)
