### PR TITLE
Add CSRF_TRUSTED_ORIGINS as optional environment variable

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -475,6 +475,8 @@ NOTIFICATION_PLUGIN_DIRS = [
 
 ADMIN_IP_WHITELIST = json.loads(os.environ.get('ADMIN_IP_WHITELIST') or '[]')
 
+CSRF_TRUSTED_ORIGINS = json.loads(os.environ.get('CSRF_TRUSTED_ORIGINS') or '[]')
+
 # This line prevents warning messages after 3.2
 # https://docs.djangoproject.com/en/4.0/releases/3.2/#customizing-type-of-auto-created-primary-keys
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ x-web-defaults: &web-defaults
     ADMIN_IP_WHITELIST: '${ADMIN_IP_WHITELIST-}'
     SITE_USES_HTTPS: '${SITE_USES_HTTPS-False}'
     SITE_IS_PUBLIC: '${SITE_IS_PUBLIC-False}'
+    CSRF_TRUSTED_ORIGINS: '${CSRF_TRUSTED_ORIGINS-}'
     SOCIAL_LOGIN: '${SOCIAL_LOGIN-False}'
     REDIS_URL: '${REDIS_URL-redis://redis:6379}'
     DATABASE_URL: '${DATABASE_URL-sqlite:////app/db.sqlite3}'

--- a/dotenv.example
+++ b/dotenv.example
@@ -27,6 +27,9 @@
 # SITE_IS_PUBLIC=False
 # set it to True if the site configured in django admin is accessible from the internet
 
+# CSRF_TRUSTED_ORIGINS=
+# A list of trusted origins for unsafe requests (e.g. POST). For example: ["https://obico.mydomain.com", "https://*.example.com"]. Necessary if, for example, a Cloudflare tunnel is used for external access.
+
 # SOCIAL_LOGIN=False
 # Set it to True to allow social account login. You will need to set "Provider" in Django admin (https://django-allauth.readthedocs.io/en/latest/providers.html)
 


### PR DESCRIPTION
I had an issue using obico behind a cloudflare tunnel. Hence, CSRF_TRUSTED_ORIGINS must be set in the django config (https://docs.djangoproject.com/en/5.0/ref/settings/#csrf-trusted-origins). This PR adds an optional parameter to the .env to set theses trusted origins.

```
Forbidden (403)
CSRF verification failed. Request aborted.

Help
Reason given for failure:

    Origin checking failed - https://obico.rasgi.de does not match any trusted origins.
    
In general, this can occur when there is a genuine Cross Site Request Forgery, or when [Django’s CSRF mechanism](https://docs.djangoproject.com/en/4.0/ref/csrf/) has not been used correctly. For POST forms, you need to ensure:

Your browser is accepting cookies.
The view function passes a request to the template’s [render](https://docs.djangoproject.com/en/dev/topics/templates/#django.template.backends.base.Template.render) method.
In the template, there is a {% csrf_token %} template tag inside each POST form that targets an internal URL.
If you are not using CsrfViewMiddleware, then you must use csrf_protect on any views that use the csrf_token template tag, as well as those that accept the POST data.
The form has a valid CSRF token. After logging in in another browser tab or hitting the back button after a login, you may need to reload the page with the form, because the token is rotated after a login.
You’re seeing the help section of this page because you have DEBUG = True in your Django settings file. Change that to False, and only the initial error message will be displayed.

You can customize this page using the CSRF_FAILURE_VIEW setting.
```

![image](https://github.com/TheSpaghettiDetective/obico-server/assets/4464088/f144d40a-3f6d-48dd-9266-5a010e2179d2)