### PR TITLE
ml_api pin Flask version to 2.x in and drop redis

### DIFF
--- a/ml_api/Dockerfile.base_arm64
+++ b/ml_api/Dockerfile.base_arm64
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -y ca-certificates build-essential gcc g++ cmake git
 WORKDIR /
 # Lock darknet version for reproducibility
-RUN git clone https://github.com/AlexeyAB/darknet --depth 1 && cd darknet && git checkout 59c86222c5387bffd9108a21885f80e980ece234
+RUN git clone https://github.com/AlexeyAB/darknet && cd darknet && git checkout 59c86222c5387bffd9108a21885f80e980ece234
 ENV LIBRARY_PATH="${LIBRARY_PATH}:/usr/local/cuda/targets/aarch64-linux/lib:/usr/local/cuda/targets/aarch64-linux/lib/stubs"
 # compile CPU version
 RUN cd darknet \

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -1,7 +1,7 @@
-ipdb
-flask>=1.0
-redis==3.0.1
-newrelic==4.12.0.113
-sentry_sdk[flask]==1.5.10
-requests==2.21.0
+flask==2.3.3
 gunicorn==19.9.0
+ipdb
+newrelic==4.12.0.113
+redis==3.0.1
+requests==2.21.0
+sentry_sdk[flask]==1.5.10

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -1,7 +1,6 @@
 flask==2.3.3
-gunicorn==19.9.0
+gunicorn==21.2.0
 ipdb
 newrelic==4.12.0.113
-redis==3.0.1
-requests==2.21.0
-sentry_sdk[flask]==1.5.10
+requests==2.31.0
+sentry_sdk[flask]==1.40.3


### PR DESCRIPTION
- Previously Flask>=1.0 would trigger installing Flask 3.x which apparently is incompatible with current Obico code.
- remove redis from mlapi/requests.txt because ml_api does not use it
- bump gunicorn version
- bump sentry version (not tested though with sentry)
- bump requests version
- fix build on arm64 (jetson nano)

Also sort requirements.txt alphabetically.
That's why PR looks like eye bleed.