### PR TITLE
Add better error messages to ml_api

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ npm_modules/
 __pycache__
 .git
 backend/static_build/
+darknet/

--- a/ml_api/.dockerignore
+++ b/ml_api/.dockerignore
@@ -1,3 +1,7 @@
-model/*.onnx
+.*
+**/*.pyc
+Dockerfile*
+Makefile
 model/*.darknet
+model/*.onnx
 

--- a/ml_api/.gitignore
+++ b/ml_api/.gitignore
@@ -1,2 +1,2 @@
-model/*.onnx
 model/*.darknet
+model/*.onnx

--- a/ml_api/Dockerfile
+++ b/ml_api/Dockerfile
@@ -2,11 +2,22 @@ FROM thespaghettidetective/ml_api_base:1.4
 WORKDIR /app
 EXPOSE 3333
 
-ADD . /app
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
+COPY . /app
+RUN pip install --no-cache-dir --upgrade pip==23.3.2 \
+    && hash -r \
+    && pip install  --no-cache-dir  -r requirements.txt
 
-RUN echo 'Downloading the latest failure detection AI model in Darknet format...'
-RUN wget -O model/model-weights.darknet $(cat model/model-weights.darknet.url | tr -d '\r')
-RUN echo 'Downloading the latest failure detection AI model in ONNX format...'
-RUN wget -O model/model-weights.onnx $(cat model/model-weights.onnx.url | tr -d '\r')
+RUN echo 'Downloading the latest failure detection AI model in Darknet format...' \
+    && wget --progress=dot:giga -O model/model-weights.darknet -i model/model-weights.darknet.url
+RUN echo 'Downloading the latest failure detection AI model in ONNX format...' \
+    && wget --progress=dot:giga -O model/model-weights.onnx -i model/model-weights.onnx.url
+
+# do not write .pyc files which is useful in read-only containers
+ENV PYTHONDONTWRITEBYTECODE=1
+
+# define where darknet is stored in container image
+ENV DARKNET_PATH=/darknet
+
+# check if we can load app, if any python import fails then it will fail image build
+RUN gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi --check-config --preload -e DARKNET_PATH=$DARKNET_PATH
+

--- a/ml_api/lib/darknet.py
+++ b/ml_api/lib/darknet.py
@@ -126,9 +126,12 @@ class YoloNet:
 lib = None
 using_gpu = False
 
+DARKNET_PATH=os.getenv('DARKNET_PATH', '../darknet')
+print(f"DARKNET_PATH={DARKNET_PATH}")
+
 print('\n')
 try:
-    so_path = os.path.join('/darknet', "libdarknet_gpu.so")
+    so_path = os.path.join(DARKNET_PATH, "libdarknet_gpu.so")
     print(f"Let's try darknet lib built with GPU support - {so_path}")
     lib = CDLL(so_path, RTLD_GLOBAL)
     print(f"Done! Hooray! Now we have darknet with GPU support.")
@@ -137,7 +140,7 @@ try:
 except Exception as e:
     print(f"Nope! Failed to load darknet lib built with GPU support. erors={e}")
 
-    so_path = os.path.join('/darknet', "libdarknet_cpu.so")
+    so_path = os.path.join(DARKNET_PATH, "libdarknet_cpu.so")
     print(f"Now let's try darknet lib on CPU - {so_path}")
     lib = CDLL(so_path, RTLD_GLOBAL)
     print(f"Done! Darknet is now running on CPU.")

--- a/ml_api/model/model.meta
+++ b/ml_api/model/model.meta
@@ -1,2 +1,2 @@
 classes= 1
-names = /app/model/names
+names = model/names

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -4,6 +4,6 @@ ipdb
 newrelic==4.12.0.113
 onnxruntime
 onnxruntime-gpu
-opencv-python
+opencv-python-headless
 requests==2.31.0
 sentry_sdk[flask]==1.40.3

--- a/ml_api/requirements.txt
+++ b/ml_api/requirements.txt
@@ -2,5 +2,8 @@ flask==2.3.3
 gunicorn==21.2.0
 ipdb
 newrelic==4.12.0.113
+onnxruntime
+onnxruntime-gpu
+opencv-python
 requests==2.31.0
 sentry_sdk[flask]==1.40.3

--- a/ml_api/server.py
+++ b/ml_api/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import flask
-from flask import request, jsonify
+from flask import abort, make_response, request, jsonify
 from os import path, environ
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -12,48 +12,89 @@ import requests
 from auth import token_required
 from lib.detection_model import load_net, detect
 
-THRESH = 0.08  # The threshold for a box to be considered a positive detection
-SESSION_TTL_SECONDS = 60*2
+# connection timeouts for python.requests for connect/read, bump it for slow endpoints
+# especially if using esp32 cameras directly
+TIMEOUT_CONNECT = float(environ.get("TIMEOUT_CONNECT", "0.1"))
+TIMEOUT_READ = float(environ.get("TIMEOUT_READ", "5"))
+# The threshold for a box to be considered a positive detection
+THRESH = float(environ.get("THRESH", "0.08"))
+SESSION_TTL_SECONDS = float(environ.get("SESSION_TTL_SECONDS", 60 * 2))
+app = flask.Flask(__name__)
 
 # Sentry
-if environ.get('SENTRY_DSN'):
+if environ.get("SENTRY_DSN"):
+    app.logger.info(f"SENTRY_DSN=***masked***")
     sentry_sdk.init(
-        dsn=environ.get('SENTRY_DSN'),
-        integrations=[FlaskIntegration(), ],
+        dsn=environ.get("SENTRY_DSN"),
+        integrations=[
+            FlaskIntegration(),
+        ],
     )
-
-app = flask.Flask(__name__)
 
 status = dict()
 
 # SECURITY WARNING: don't run with debug turned on in production!
-app.config['DEBUG'] = environ.get('DEBUG') == 'True'
+app.config["DEBUG"] = environ.get("DEBUG") == "True"
 
-model_dir = path.join(path.dirname(path.realpath(__file__)), 'model')
-net_main = load_net(path.join(model_dir, 'model.cfg'), path.join(model_dir, 'model.meta'))
+app.logger.info(f"DEBUG={app.config['DEBUG']}")
+app.logger.info(f"SESSION_TTL_SECONDS={SESSION_TTL_SECONDS}")
+app.logger.info(f"THRESH={THRESH}")
+app.logger.info(f"TIMEOUT_CONNECT={TIMEOUT_CONNECT}")
+app.logger.info(f"TIMEOUT_READ={TIMEOUT_READ}")
 
-@app.route('/p/', methods=['GET'])
+# load ai/ml models
+model_dir = path.join(path.dirname(path.realpath(__file__)), "model")
+net_main = load_net(
+    path.join(model_dir, "model.cfg"), path.join(model_dir, "model.meta")
+)
+
+
+# process detection of the image, pass 'img' as param
+@app.route("/p/", methods=["GET"])
 @token_required
 def get_p():
-    if 'img' in request.args:
+    if "img" in request.args:
         try:
-            resp = requests.get(request.args['img'], stream=True, timeout=(0.1, 5))
+            resp = requests.get(
+                request.args["img"],
+                stream=True,
+                timeout=(TIMEOUT_CONNECT, TIMEOUT_READ),
+            )
             resp.raise_for_status()
             img_array = np.array(bytearray(resp.content), dtype=np.uint8)
             img = cv2.imdecode(img_array, -1)
             detections = detect(net_main, img, thresh=THRESH)
-            return jsonify({'detections': detections})
-        except:
+            return jsonify({"detections": detections})
+        except Exception as err:
             sentry_sdk.capture_exception()
+            app.logger.error(f"Failed to get image {request.args} - {err}")
+            abort(
+                make_response(
+                    jsonify(
+                        detections=[],
+                        message=f"Failed to get image {request.args} - {err}",
+                    ),
+                    503,
+                )
+            )
+
     else:
-        app.logger.warn("Invalid request params: {}".format(request.args))
+        app.logger.warn(f"Invalid request params: {request.args}")
+        abort(
+            make_response(
+                jsonify(
+                    detections=[], message=f"Invalid request params: {request.args}"
+                ),
+                400,
+            )
+        )
 
-    # todo, not a correct way to report an error if exception
-    return jsonify({'detections': []})
 
-@app.route('/hc/', methods=['GET'])
+# healtchcheck and readiness endpoint
+@app.route("/hc/", methods=["GET"])
 def health_check():
-    return 'ok' if net_main is not None else 'error'
+    return "ok" if net_main is not None else "error"
+
 
 if __name__ == "__main__":
-    app.run(host='0.0.0.0', port=3333, threaded=False)
+    app.run(host="0.0.0.0", port=3333, threaded=False)


### PR DESCRIPTION
```text
21:09:24 kaszpir@lynx ~/Downloads $ curl -v "http://127.0.0.1:13333/p/?img=http://bagno.hldspl/obico/bad_1.jpg"
*   Trying 127.0.0.1:13333...
* Connected to 127.0.0.1 (127.0.0.1) port 13333 (#0)
> GET /p/?img=http://bagno.hldspl/obico/bad_1.jpg HTTP/1.1
> Host: 127.0.0.1:13333
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 503 SERVICE UNAVAILABLE
< Server: gunicorn
< Date: Fri, 16 Feb 2024 20:28:40 GMT
< Connection: keep-alive
< Content-Type: application/json
< Content-Length: 399
< 
{
  "detections": [],
  "message": "Failed to get image ImmutableMultiDict([('img', 'http://bagno.hldspl/obico/bad_1.jpg')]) - HTTPConnectionPool(host='bagno.hldspl', port=80): Max retries exceeded with url: /obico/bad_1.jpg (Caused by NameResolutionError(\"<urllib3.connection.HTTPConnection object at 0x7f5ec33676d0>: Failed to resolve 'bagno.hldspl' ([Errno -2] Name or service not known)\"))"
}
* Connection #0 to host 127.0.0.1 left intact
```

gunicorn logs (sorry, I guess I mixed stdout with stderr in one output below):
```text
[2024-02-16 20:28:40,289] ERROR in server: Failed to get image ImmutableMultiDict([('img', 'http://bagno.hldspl/obico/bad_1.jpg')]) - HTTPConnectionPool(host='bagno.hldspl', port=80): Max retries exceeded with url: /obico/bad_1.jpg (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x7f5ec33676d0>: Failed to resolve 'bagno.hldspl' ([Errno -2] Name or service not known)"))
172.17.0.1 - - [16/Feb/2024:20:28:40 +0000] "GET /p/?img=http://bagno.hldspl/obico/bad_1.jpg HTTP/1.1" 503 399 "-" "curl/7.81.0"
```