### PR TITLE
Add better error messages to ml_api

### DIFF
--- a/ml_api/server.py
+++ b/ml_api/server.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import flask
-from flask import request, jsonify
+from flask import abort, make_response, request, jsonify
 from os import path, environ
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -45,11 +45,27 @@ def get_p():
             return jsonify({'detections': detections})
         except:
             sentry_sdk.capture_exception()
+            app.logger.error(f"Failed to get image {request.args} - {err}")
+            abort(
+                make_response(
+                    jsonify(
+                        detections=[],
+                        message=f"Failed to get image {request.args} - {err}",
+                    ),
+                    503,
+                )
+            )
     else:
-        app.logger.warn("Invalid request params: {}".format(request.args))
+        app.logger.warn(f"Invalid request params: {request.args}")
+        abort(
+            make_response(
+                jsonify(
+                    detections=[], message=f"Invalid request params: {request.args}"
+                ),
+                400,
+            )
+        )
 
-    # todo, not a correct way to report an error if exception
-    return jsonify({'detections': []})
 
 @app.route('/hc/', methods=['GET'])
 def health_check():

--- a/ml_api/server.py
+++ b/ml_api/server.py
@@ -43,7 +43,7 @@ def get_p():
             img = cv2.imdecode(img_array, -1)
             detections = detect(net_main, img, thresh=THRESH)
             return jsonify({'detections': detections})
-        except:
+        except Exception as err:
             sentry_sdk.capture_exception()
             app.logger.error(f"Failed to get image {request.args} - {err}")
             abort(
@@ -52,7 +52,7 @@ def get_p():
                         detections=[],
                         message=f"Failed to get image {request.args} - {err}",
                     ),
-                    503,
+                    400,
                 )
             )
     else:
@@ -62,7 +62,7 @@ def get_p():
                 jsonify(
                     detections=[], message=f"Invalid request params: {request.args}"
                 ),
-                400,
+                422,
             )
         )
 


### PR DESCRIPTION
```text
21:50:49 kaszpir@lynx ~/Downloads $ curl -v "http://127.0.0.1:13333/p/?img=http://bagno.hldspl/obico/bad_1.jpg"
*   Trying 127.0.0.1:13333...
* Connected to 127.0.0.1 (127.0.0.1) port 13333 (#0)
> GET /p/?img=http://bagno.hldspl/obico/bad_1.jpg HTTP/1.1
> Host: 127.0.0.1:13333
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 503 SERVICE UNAVAILABLE
< Server: gunicorn
< Date: Fri, 16 Feb 2024 20:51:09 GMT
< Connection: keep-alive
< Content-Type: application/json
< Content-Length: 399
< 
{
  "detections": [],
  "message": "Failed to get image ImmutableMultiDict([('img', 'http://bagno.hldspl/obico/bad_1.jpg')]) - HTTPConnectionPool(host='bagno.hldspl', port=80): Max retries exceeded with url: /obico/bad_1.jpg (Caused by NameResolutionError(\"<urllib3.connection.HTTPConnection object at 0x7fa26ae25760>: Failed to resolve 'bagno.hldspl' ([Errno -2] Name or service not known)\"))"
}
* Connection #0 to host 127.0.0.1 left intact
```

gunicorn log:
```text
[2024-02-16 20:51:09,449] ERROR in server: Failed to get image ImmutableMultiDict([('img', 'http://bagno.hldspl/obico/bad_1.jpg')]) - HTTPConnectionPool(host='bagno.hldspl', port=80): Max retries exceeded with url: /obico/bad_1.jpg (Caused by NameResolutionError("<urllib3.connection.HTTPConnection object at 0x7fa26ae25760>: Failed to resolve 'bagno.hldspl' ([Errno -2] Name or service not known)"))
172.17.0.1 - - [16/Feb/2024:20:51:09 +0000] "GET /p/?img=http://bagno.hldspl/obico/bad_1.jpg HTTP/1.1" 503 399 "-" "curl/7.81.0"
```