### PR TITLE
Allow relocating media root

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -453,7 +453,7 @@ GOOGLE_APPLICATION_CREDENTIALS = os.environ.get(
     'GOOGLE_APPLICATION_CREDENTIALS')
 
 MEDIA_URL = '/media/'
-MEDIA_ROOT = os.path.join(STATIC_ROOT, 'media')
+MEDIA_ROOT = os.environ.get('MEDIA_ROOT', os.path.join(STATIC_ROOT, 'media'))
 INTERNAL_MEDIA_HOST = os.environ.get('INTERNAL_MEDIA_HOST')
 
 PICS_CONTAINER = os.environ.get('PICS_CONTAINER', 'tsd-pics')


### PR DESCRIPTION
When self hosting, I make backups of the data I cannot recreate-- a lesson I learned the hard way.  Right now, all user files (eg. time lapses) are stored under the hardcoded path `<gitrepo>/backend/static_build/media` which is intermingled with the source. I want to back up the user files and database, but not the source (it's easy to re-clone it and recreate the containers).

The database can already be redirected to a different file with an environment variable for expert users. This trivial change adds a similar MEDIA_ROOT env var for expert users so that all uploaded files can go to a different place if desired.