### PR TITLE
feat(chart): add a startup probe for ml-api and document the arm64 and Jetson images

### DIFF
--- a/charts/obico/Chart.yaml
+++ b/charts/obico/Chart.yaml
@@ -2,13 +2,27 @@ annotations:
   artifacthub.io/category: ai-machine-learning
   # Valid kinds for changes: added, changed, deprecated, removed, fixed, security
   # See: https://artifacthub.io/docs/topics/annotations/helm/
+  # A minor rather than a patch: mlApi.command gains --timeout=120, so the
+  # rendered Deployment changes for everyone on the defaults. The rest is the
+  # images the chart already pulls plus documentation of which fit which
+  # hardware.
   artifacthub.io/changes: |-
     - kind: changed
-      description: Raise the tasks container memory limit to 2Gi and CPU limit to a full core so the post-print ffmpeg timelapse encode is no longer OOM-killed
+      description: The web and CPU inference images are now published for linux/arm64 as well as linux/amd64, so the chart installs on arm64 clusters
     - kind: changed
-      description: Raise the bundled redis memory request to 256Mi and limit to 512Mi to match its observed steady-state footprint
+      description: Documented running the NVIDIA Jetson inference image by pointing the GPU image slot at it
+    - kind: changed
+      description: The CPU inference image moves OpenCV from 4.9 to 4.12, the preprocessing step that runs before every detection
+    - kind: changed
+      description: The ml-api command gains --timeout=120 so a slow model load cannot leave the pod respawning its worker forever without ever going ready
     - kind: added
-      description: Publish the chart as a signed OCI artifact to GHCR with image tags pinned to the matching CalVer build
+      description: Every ml-api pod gains a startup probe, so an image that cannot load its model within the deadline now crash-loops visibly instead of sitting not-ready with a green liveness check
+    - kind: added
+      description: mlApi.startupBudgetSeconds sets how long that probe waits, and the chart refuses to render when it is not above the deadline in mlApi.command
+    - kind: changed
+      description: The ml-api readiness probe drops its initial delay, since the startup probe now covers the boot window
+    - kind: added
+      description: That probe caps every ml-api boot at mlApi.startupBudgetSeconds, including commands whose deadline the chart cannot read. A container that used to stay not-ready for as long as the load took is now restarted; raise the budget if the model needs longer
   artifacthub.io/license: BSD-3-Clause
   artifacthub.io/links: |
     - name: Obico Server
@@ -17,9 +31,12 @@ apiVersion: v2
 name: obico
 description: Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
 type: application
-version: "0.2.0"
-# CalVer derived from the obico-server release commit these images are built from.
-appVersion: "2026.1.20"
+version: "0.3.0"
+# CalVer of the release commit these images are built from. The publish job
+# overwrites this with the CalVer of the commit it is building, so the value
+# here only reaches someone installing the chart straight from a checkout —
+# which is exactly why it should not be left naming a commit that never existed.
+appVersion: "2026.7.11"
 icon: https://www.obico.io/img/logo.svg
 home: https://www.obico.io/
 keywords:

--- a/charts/obico/README.md
+++ b/charts/obico/README.md
@@ -1,6 +1,6 @@
 # obico
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.1.20](https://img.shields.io/badge/AppVersion-2026.1.20-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.7.11](https://img.shields.io/badge/AppVersion-2026.7.11-informational?style=flat-square)
 
 Self-hosted Obico server for AI-powered 3D printer monitoring (OctoPrint/Klipper)
 
@@ -21,11 +21,13 @@ This chart deploys the full stack:
 
 Obico's docker-compose builds the server images from source. This chart consumes prebuilt, tagged equivalents produced by the repository's own workflow (`.github/workflows/build-images.yaml`), which builds from the release branch and publishes to GHCR:
 
-* `obico-web` — Django/Daphne app + Celery worker
-* `obico-ml-api-cpu` — slim CPU inference image (chart default)
-* `obico-ml-api-gpu` — CUDA inference image for GPU nodes
+* `obico-web` — Django/Daphne app + Celery worker (`linux/amd64` and `linux/arm64`)
+* `obico-ml-api-cpu` — slim CPU inference image, the chart default (`linux/amd64` and `linux/arm64`)
+* `obico-ml-api-gpu` — CUDA inference image for GPU nodes (`linux/amd64` only)
 
-By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag`: `sha-<short>` is immutable per commit, while a CalVer like `2026.7.1` is day-granular (it moves if two commits land the same UTC day). Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
+The workflow also publishes an L4T image for NVIDIA Jetson on a best-effort basis: it is exercised as a CI build only and has never been started on real hardware, and a given release may ship without it. The chart has no separate switch for it, but it needs none: point the GPU slot at that image and turn the GPU on.
+
+By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag` to an immutable tag: `<calver>-g<short>` (e.g. `2026.7.11-g49c0bc70`) is the readable one, `sha-<short>` the terse one, and both name the same build. For an **image** tag, prefer `sha-<short>` when something automated does the pinning: semver reads the combined form as a prerelease of the CalVer, so version-comparing tools rank it *below* the plain `2026.7.11` and skip it by default. A bare CalVer like `2026.7.11` is day-granular and moves if two commits land the same UTC day. The moving tags also move per image rather than in step: each image's manifest is published on its own, so if one image fails to build, `release` still advances for the others and a deployment left on the moving tags can end up mixing builds. Pinning avoids that as well. Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
 
 ## Maintainers
 
@@ -43,7 +45,7 @@ Kubernetes: `>=1.21.0-0`
 
 ## Installing the Chart
 
-The image-build workflow also packages this chart and pushes it to GHCR as an OCI artifact. That published chart pins the Obico images (web and both ml-api variants) to the immutable `sha-<short>` tag of the commit they were built from, so an install from the artifact is reproducible and needs no checkout. Pick a version (CalVer, e.g. `2026.1.20`) from the [package page](https://github.com/TheSpaghettiDetective/obico-server/pkgs/container/charts%2Fobico):
+The image-build workflow also packages this chart and pushes it to GHCR as an OCI artifact. That published chart pins the Obico images (web and both ml-api variants it can select between) to the immutable `sha-<short>` tag of the commit they were built from, so an install from the artifact is reproducible and needs no checkout. Pick a version from the [package page](https://github.com/TheSpaghettiDetective/obico-server/pkgs/container/charts%2Fobico). Each release publishes two: the CalVer (e.g. `2026.7.11`), which is day-granular and moves if two releases land on the same UTC day, and `<calver>-g<short>` (e.g. `2026.7.11-g49c0bc70`), which never moves. For the **chart** version there is no terse alternative, so pin the combined form for anything that redeploys on its own — but note that semver reads it as a prerelease, and Helm, Flux and Renovate all skip prereleases unless told otherwise, so an updater pointed at this chart will not offer you a move off a pinned version by itself. Note also that the immutable name is a registry tag rather than a second chart version: install by it and Helm still reports the plain CalVer in `helm list` and in the `helm.sh/chart` label, because that is what the packaged `Chart.yaml` says:
 
 ```bash
 # From the published OCI artifact (images pinned to the build commit)
@@ -186,10 +188,33 @@ The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** sing
 
 ## ML inference image (CPU / GPU)
 
-The `ml-api` service ships as two images built from the same source:
+The chart deploys one of two `ml-api` images built from the same source:
 
 * **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image. This is what the chart deploys by default and it runs on any node.
-* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it. Published for `linux/amd64` only, so on an arm64 cluster enabling it fails the pull. Generic arm64 nodes use the CPU image; on an NVIDIA Jetson, point the GPU slot at the L4T image instead:
+
+  ```yaml
+  mlApi:
+    gpu: true
+    # Only if the cluster advertises it. Where the Jetson container runtime
+    # exposes the device without a plugin, nothing provides this resource and
+    # the pod sits in Pending — set this to null there. Not {}: Helm merges
+    # maps key by key, so an empty one contributes nothing and the default
+    # below survives, while null deletes the key.
+    gpuResources:
+      nvidia.com/gpu: 1
+  image:
+    mlApi:
+      gpu:
+        repository: ghcr.io/thespaghettidetective/obico-ml-api-jetson
+        tag: release
+  ```
+
+  The `tag` matters: the published chart pins `image.mlApi.gpu.tag` to the commit it was built from, and the Jetson build is best-effort, so that exact build may not exist under this name. A pull that fails with an authentication error usually means the package has not been made public yet rather than that your credentials are wrong. `release` follows the latest one that succeeded — note that for this image alone, "succeeded" means it compiled and passed two container-start smoke checks, not that it serves: the other two inference images are launched in CI and asked for a health response, and no runner has Tegra drivers to give this one the same treatment. Pin it to a specific build once you have one that works on your board.
+
+  Expect to raise `mlApi.startupBudgetSeconds` here. It is the ceiling on how long the container may take to answer `/hc/` before the startup probe restarts it, it defaults to 140 seconds, and a Jetson initialising CUDA and loading the model at import is the slowest start in this project — past the budget the pod goes to CrashLoopBackOff rather than eventually coming up. Raise `--timeout` in `mlApi.command` together with it, since rendering fails unless the budget stays above that deadline.
+
+  On a mixed cluster note that `nodeSelector`, `affinity` and `tolerations` in this chart apply to every component, so there is no way to pin ml-api to amd64 nodes without pinning web and redis there too.
 
 Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
 
@@ -225,8 +250,8 @@ To skip AI failure detection entirely, set `mlApi.enabled: false`. Obico still c
 | httpRoute.hostnames | list | `["obico.example.com"]` | Hostnames for the route |
 | httpRoute.parentRefs | list | `[{"name":"gateway","namespace":"gateway-system"}]` | Parent Gateway references |
 | httpRoute.rules | list | `[{"matches":[{"path":{"type":"PathPrefix","value":"/"}}]}]` | Routing rules |
-| image | object | `{"mlApi":{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/thespaghettidetective/obico-web","tag":""}}` | Container images. Built from obico-server source by the in-repo workflow (.github/workflows/build-images.yaml) and published to GHCR under the repository owner's namespace (ghcr.io/thespaghettidetective/* upstream). Each tag defaults to the "release" moving tag the workflow publishes on the release branch; pin a specific tag (a CalVer like 2026.7.1 or sha-<short>) for reproducibility. |
-| image.mlApi | object | `{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"}` | ML inference API images. Two variants are published from the same source: a slim CPU-only image (default) and a CUDA image for GPU inference. mlApi.gpu selects which one runs; configure each variant independently. |
+| image | object | `{"mlApi":{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"},"web":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/thespaghettidetective/obico-web","tag":""}}` | Container images. Built from obico-server source by the in-repo workflow (.github/workflows/build-images.yaml) and published to GHCR under the repository owner's namespace (ghcr.io/thespaghettidetective/* upstream). Each tag defaults to the "release" moving tag the workflow publishes on the release branch; pin an immutable tag for reproducibility: `<calver>-g<short>` (e.g. `2026.7.11-g49c0bc70`) or the terse `sha-<short>`. |
+| image.mlApi | object | `{"cpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""},"gpu":{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""},"pullPolicy":"IfNotPresent"}` | ML inference API images. The chart runs one of two variants built from the same source: a slim CPU-only image (default) and a CUDA image for GPU inference. mlApi.gpu selects which one runs; configure each variant independently. |
 | image.mlApi.cpu | object | `{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-cpu","tag":""}` | CPU-only inference image (slim). Used when mlApi.gpu is false. |
 | image.mlApi.cpu.tag | string | `""` | Overrides the CPU image tag whose default is the "release" moving tag |
 | image.mlApi.gpu | object | `{"repository":"ghcr.io/thespaghettidetective/obico-ml-api-gpu","tag":""}` | CUDA inference image (large). Used when mlApi.gpu is true. |
@@ -235,8 +260,8 @@ To skip AI failure detection entirely, set `mlApi.enabled: false`. Obico still c
 | image.web.tag | string | `""` | Overrides the image tag whose default is the "release" moving tag |
 | imagePullSecrets | list | `[]` |  |
 | ingress | object | `{"annotations":{},"className":"","enabled":false,"hosts":[{"host":"obico.example.com","paths":[{"path":"/","pathType":"Prefix"}]}],"tls":[{"hosts":["obico.example.com"],"secretName":"obico-tls"}]}` | Ingress configuration |
-| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"],"enabled":true,"externalHost":"","gpu":false,"gpuResources":{"nvidia.com/gpu":1},"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{}}` | ML inference API (AI failure detection). Can be disabled. |
-| mlApi.command | list | `["gunicorn","--bind=0.0.0.0:3333","--workers=1","--access-logfile=-","wsgi"]` | Command for the gunicorn inference server |
+| mlApi | object | `{"command":["gunicorn","--bind=0.0.0.0:3333","--workers=1","--timeout=120","--access-logfile=-","wsgi"],"enabled":true,"externalHost":"","gpu":false,"gpuResources":{"nvidia.com/gpu":1},"replicaCount":1,"resources":{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"securityContext":{},"startupBudgetSeconds":140}` | ML inference API (AI failure detection). Can be disabled. |
+| mlApi.command | list | `["gunicorn","--bind=0.0.0.0:3333","--workers=1","--timeout=120","--access-logfile=-","wsgi"]` | Command for the gunicorn inference server. The `--timeout` flag is load-bearing: the model is loaded at import, so it happens inside worker boot, and the default 30s arbiter deadline would kill the worker and respawn it forever on a slower node — the pod would never go ready and never crash-loop, so nothing would say why. Note it is not boot-only: the same value bounds request handling, and with a single worker a stalled inference holds that worker for the whole period before the arbiter recycles it. Readiness drops the pod out of the Service after 60s of that, which is the only part probes can help with; the boot case belongs to startupBudgetSeconds, which has to stay above whatever is set here. Not solved with gunicorn `--preload`, which would load the model in the arbiter and take it out from under this deadline: server.py calls load_net at import, and on the GPU images that initialises CUDA or opens a CUDAExecutionProvider session, and `--preload` still forks the worker afterwards. |
 | mlApi.enabled | bool | `true` | Deploy the ML inference API |
 | mlApi.externalHost | string | `""` | External ML inference API URL, used when enabled is false. Obico still calls the ML API for prints that have AI detection on, so if you disable the bundled ml-api, either point this at an external instance (e.g. http://ml-api:3333) or make sure AI detection is off on every printer — otherwise picture uploads that request detection will error. |
 | mlApi.gpu | bool | `false` | Run the CUDA (GPU) inference image instead of the slim CPU default. When true the ml-api container uses image.mlApi.gpu and requests the accelerator from gpuResources; requires an NVIDIA GPU and device plugin on the node. The CPU image works everywhere and is far smaller, so leave this false unless you actually have a GPU. |
@@ -244,6 +269,7 @@ To skip AI failure detection entirely, set `mlApi.enabled: false`. Obico still c
 | mlApi.replicaCount | int | `1` | Number of ml-api replicas |
 | mlApi.resources | object | `{"limits":{"cpu":"2","memory":"2Gi"},"requests":{"cpu":"500m","memory":"1Gi"}}` | Resource requests/limits for the ml-api container |
 | mlApi.securityContext | object | `{}` | Security context for the ml-api container. Left empty (image default = root) because the upstream CUDA-based ml-api image is not validated to run unprivileged (model cache and runtime expect root). Harden here once confirmed it runs as non-root in your environment. |
+| mlApi.startupBudgetSeconds | int | `140` | Seconds the container gets to answer /hc/ before Kubernetes restarts it. Has to stay above the `--timeout` in command, or the pod is killed while the first worker still has time left to finish loading; rendering fails when it is not. Raise both together on hardware where the model takes longer than this to load, and note that raising this alone only delays the restart of an image that cannot boot at all. This is the boot ceiling for every shape of command, including the ones no deadline can be read out of: a `gunicorn.conf.py` passed with `-c`, an explicit `--timeout=0`, or a command that is not gunicorn at all. Before this chart had a startup probe such a container stayed NotReady for as long as the load took, so long as it had opened the port — the tcpSocket liveness check still ended one that never bound at all. Now the budget ends it either way, and the render-time pairing check cannot warn about a deadline it cannot see. Raise this to whatever the slowest boot needs. Spent in whole probe periods of 10s, rounded up, so a value below 10 still buys one period and one below the deadline is refused rather than rounded into looking sufficient. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | obico | object | `{"csrfTrustedOrigins":[],"debug":false,"existingSecret":"","extraEnv":{},"extraSecretEnv":{},"secretKey":"","siteUsesHttps":false}` | Obico application configuration (rendered into the env ConfigMap/Secret) |

--- a/charts/obico/README.md.gotmpl
+++ b/charts/obico/README.md.gotmpl
@@ -23,11 +23,13 @@ This chart deploys the full stack:
 
 Obico's docker-compose builds the server images from source. This chart consumes prebuilt, tagged equivalents produced by the repository's own workflow (`.github/workflows/build-images.yaml`), which builds from the release branch and publishes to GHCR:
 
-* `obico-web` — Django/Daphne app + Celery worker
-* `obico-ml-api-cpu` — slim CPU inference image (chart default)
-* `obico-ml-api-gpu` — CUDA inference image for GPU nodes
+* `obico-web` — Django/Daphne app + Celery worker (`linux/amd64` and `linux/arm64`)
+* `obico-ml-api-cpu` — slim CPU inference image, the chart default (`linux/amd64` and `linux/arm64`)
+* `obico-ml-api-gpu` — CUDA inference image for GPU nodes (`linux/amd64` only)
 
-By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag`: `sha-<short>` is immutable per commit, while a CalVer like `2026.7.1` is day-granular (it moves if two commits land the same UTC day). Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
+The workflow also publishes an L4T image for NVIDIA Jetson on a best-effort basis: it is exercised as a CI build only and has never been started on real hardware, and a given release may ship without it. The chart has no separate switch for it, but it needs none: point the GPU slot at that image and turn the GPU on.
+
+By default the chart pulls the `release` moving tag — the latest images built from the release branch at deploy time. Because that tag moves and `pullPolicy` defaults to `IfNotPresent`, already-running pods keep their pulled image until they restart. For a reproducible deployment, pin `image.*.tag` to an immutable tag: `<calver>-g<short>` (e.g. `2026.7.11-g49c0bc70`) is the readable one, `sha-<short>` the terse one, and both name the same build. For an **image** tag, prefer `sha-<short>` when something automated does the pinning: semver reads the combined form as a prerelease of the CalVer, so version-comparing tools rank it *below* the plain `2026.7.11` and skip it by default. A bare CalVer like `2026.7.11` is day-granular and moves if two commits land the same UTC day. The moving tags also move per image rather than in step: each image's manifest is published on its own, so if one image fails to build, `release` still advances for the others and a deployment left on the moving tags can end up mixing builds. Pinning avoids that as well. Alternatively set the image `pullPolicy` to `Always` to re-pull on every pod start.
 
 {{ template "chart.maintainersSection" . }}
 
@@ -37,7 +39,7 @@ By default the chart pulls the `release` moving tag — the latest images built 
 
 ## Installing the Chart
 
-The image-build workflow also packages this chart and pushes it to GHCR as an OCI artifact. That published chart pins the Obico images (web and both ml-api variants) to the immutable `sha-<short>` tag of the commit they were built from, so an install from the artifact is reproducible and needs no checkout. Pick a version (CalVer, e.g. `2026.1.20`) from the [package page](https://github.com/TheSpaghettiDetective/obico-server/pkgs/container/charts%2Fobico):
+The image-build workflow also packages this chart and pushes it to GHCR as an OCI artifact. That published chart pins the Obico images (web and both ml-api variants it can select between) to the immutable `sha-<short>` tag of the commit they were built from, so an install from the artifact is reproducible and needs no checkout. Pick a version from the [package page](https://github.com/TheSpaghettiDetective/obico-server/pkgs/container/charts%2Fobico). Each release publishes two: the CalVer (e.g. `2026.7.11`), which is day-granular and moves if two releases land on the same UTC day, and `<calver>-g<short>` (e.g. `2026.7.11-g49c0bc70`), which never moves. For the **chart** version there is no terse alternative, so pin the combined form for anything that redeploys on its own — but note that semver reads it as a prerelease, and Helm, Flux and Renovate all skip prereleases unless told otherwise, so an updater pointed at this chart will not offer you a move off a pinned version by itself. Note also that the immutable name is a registry tag rather than a second chart version: install by it and Helm still reports the plain CalVer in `helm list` and in the `helm.sh/chart` label, because that is what the packaged `Chart.yaml` says:
 
 ```bash
 # From the published OCI artifact (images pinned to the build commit)
@@ -180,10 +182,33 @@ The bundled Redis (`redis.enabled: true`) is a minimal, **unauthenticated** sing
 
 ## ML inference image (CPU / GPU)
 
-The `ml-api` service ships as two images built from the same source:
+The chart deploys one of two `ml-api` images built from the same source:
 
 * **CPU (default)** — `obico-ml-api-cpu`, a slim image that runs failure detection on the CPU via ONNX Runtime. No CUDA layers and no NVIDIA toolchain, an order of magnitude smaller than the GPU image. This is what the chart deploys by default and it runs on any node.
-* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it.
+* **GPU** — `obico-ml-api-gpu`, the CUDA image for NVIDIA GPU inference. Much larger, since the CUDA / cuDNN runtime ships inside it. Published for `linux/amd64` only, so on an arm64 cluster enabling it fails the pull. Generic arm64 nodes use the CPU image; on an NVIDIA Jetson, point the GPU slot at the L4T image instead:
+
+  ```yaml
+  mlApi:
+    gpu: true
+    # Only if the cluster advertises it. Where the Jetson container runtime
+    # exposes the device without a plugin, nothing provides this resource and
+    # the pod sits in Pending — set this to null there. Not {}: Helm merges
+    # maps key by key, so an empty one contributes nothing and the default
+    # below survives, while null deletes the key.
+    gpuResources:
+      nvidia.com/gpu: 1
+  image:
+    mlApi:
+      gpu:
+        repository: ghcr.io/thespaghettidetective/obico-ml-api-jetson
+        tag: release
+  ```
+
+  The `tag` matters: the published chart pins `image.mlApi.gpu.tag` to the commit it was built from, and the Jetson build is best-effort, so that exact build may not exist under this name. A pull that fails with an authentication error usually means the package has not been made public yet rather than that your credentials are wrong. `release` follows the latest one that succeeded — note that for this image alone, "succeeded" means it compiled and passed two container-start smoke checks, not that it serves: the other two inference images are launched in CI and asked for a health response, and no runner has Tegra drivers to give this one the same treatment. Pin it to a specific build once you have one that works on your board.
+
+  Expect to raise `mlApi.startupBudgetSeconds` here. It is the ceiling on how long the container may take to answer `/hc/` before the startup probe restarts it, it defaults to 140 seconds, and a Jetson initialising CUDA and loading the model at import is the slowest start in this project — past the budget the pod goes to CrashLoopBackOff rather than eventually coming up. Raise `--timeout` in `mlApi.command` together with it, since rendering fails unless the budget stays above that deadline.
+
+  On a mixed cluster note that `nodeSelector`, `affinity` and `tolerations` in this chart apply to every component, so there is no way to pin ml-api to amd64 nodes without pinning web and redis there too.
 
 Most self-hosted deployments run CPU inference and should keep the default. Enable the GPU image only if you have an NVIDIA GPU with the device plugin configured:
 

--- a/charts/obico/templates/NOTES.txt
+++ b/charts/obico/templates/NOTES.txt
@@ -61,6 +61,24 @@ To view logs:
 
   kubectl --namespace {{ .Release.Namespace }} logs -l "app.kubernetes.io/name={{ include "obico.name" . }},app.kubernetes.io/component=web" --tail=100 -f
 
+{{- /* Only for gunicorn: the deployment deliberately accepts a command that is
+       something else entirely, and telling those people to add an arbiter flag
+       their process does not have blames the wrong thing for a failure they
+       are not having. */}}
+{{- if and .Values.mlApi.enabled (include "obico.mlApiRunsGunicorn" .) (not (include "obico.mlApiBootDeadline" .)) }}
+
+WARNING: no timeout could be read from mlApi.command. The detection model is
+  loaded at import, so it loads inside worker boot, and on slower hardware that
+  can outrun gunicorn's 30s default: the worker is killed mid-load and
+  respawned behind a socket that stays open, so the container never answers
+  /hc/. The startup probe then restarts it once mlApi.startupBudgetSeconds runs
+  out, and that budget is the boot ceiling whatever the command does. It
+  currently allows at least {{ .Values.mlApi.startupBudgetSeconds }}s, spent in
+  whole 10s probe periods rounded up — raise it if the model genuinely needs
+  longer, and keep any --timeout you set below it, so that gunicorn gives up on
+  the worker before the probe gives up on the container.
+{{- end }}
+
 For more information:
   - Chart: https://github.com/TheSpaghettiDetective/obico-server/tree/release/charts/obico
   - Obico: https://www.obico.io/

--- a/charts/obico/templates/_helpers.tpl
+++ b/charts/obico/templates/_helpers.tpl
@@ -1,4 +1,256 @@
 {{/*
+The boot deadline gunicorn was given in mlApi.command, or nothing when the
+command names none. Read once here, because two places need it: the deployment
+sizes the startup probe against this number and NOTES warns on its absence.
+
+Matched against the joined command rather than element by element, because the
+deadline does not have to be its own argv entry. Some of the gunicorn
+invocations this repository ships sit inside a `bash -c "..."` wrapper —
+docker-compose.yml and the Jetson symlink workaround in docs/model_development.md
+both take that shape, and a Jetson user copying that workaround into
+mlApi.command is exactly who this chart now documents. To an argv walk the whole
+invocation is one opaque element, so whatever deadline it carries is invisible,
+which is wrong twice over: NOTES calls a working config broken, and the pairing
+below stops guarding the one command that most needs it.
+
+Bounded on both sides. On the left, because a wrapped command has a prelude and
+preludes carry flags: `wait-for-it -t 30`, `docker run -t`, `curl --timeout 5`.
+On the right, because what follows a `&&` or a `&` is a different command, and
+start-then-poll is the ordinary shape — `gunicorn ... & ./wait-for-it.sh -t 30
+...`. Read either boundary wrong and a neighbour's flag becomes this command's
+deadline, so a gunicorn started bare looks covered and the pairing below stops
+holding on the one command that needed it most.
+
+The first program name inside a command, not the last: `--chdir /opt/gunicorn`
+is a path argument that ends at a space, and splitting there would put the
+deadline that follows it outside the invocation it belongs to.
+
+Both spellings gunicorn accepts, `--timeout` and `-t`, and only where the flag
+names a number.
+
+A command that names a config file yields nothing here, and NOTES stays quiet
+for it. `timeout = 120` in gunicorn.conf.py is a deliberate way to set this and
+the chart cannot read that file, so calling the deadline missing would send
+someone to add a flag they moved on purpose.
+*/}}
+{{/*
+One command, and whether it starts gunicorn. Two ways to qualify, because the
+container's command and a shell wrapper are different shapes. A command whose
+own program is gunicorn is an invocation whatever flags follow. Inside a
+wrapper the word can also be a mention — `echo starting gunicorn` — so there a
+flag only an invocation carries is required. A bare mention stays a mention;
+one written next to a gunicorn-looking flag does not.
+
+What that costs depends on which flag. `echo starting gunicorn -w 2` is read as
+an invocation and prints one NOTES line nobody needed, which is cheap. A
+mention carrying the deadline flag is not: `echo about to start gunicorn -t 600`
+hands 600 to the pairing check as this command's boot deadline, and any value
+above startupBudgetSeconds refuses the render outright, naming a deadline no
+process here has. Both are the price of deciding invocation from a flag rather
+than from a running program, and the second one is what anyone loosening or
+tightening this heuristic later is really trading against.
+
+Both spellings of that flag, for the same reason the deadline is read in both:
+gunicorn documents `-b` and `-w` alongside `--bind` and `--workers`, and a
+check that knows only the long ones judges a command it cannot read. Wrapped
+plus short-flagged is a real shape — it is what fits on one `bash -c` line —
+and missing it costs twice, since the deadline pairing stops guarding that
+command and NOTES stops warning when it has no deadline at all.
+
+Value attached or separated, because argparse takes a short option's value
+either way and `-b0.0.0.0:3333 -w1` is the terser habit. Insisting on a
+separator here while the deadline below reads `-t600` attached would leave one
+half of the same check unable to read what the other half accepts.
+
+The deadline flag counts as a marker too, and it is the one that matters most.
+`exec gunicorn --timeout=600 wsgi` is an ordinary thing to write inside a
+wrapper — `exec` is how the server ends up as PID 1 — and a command carrying
+`--timeout` is no less an invocation than one carrying `--bind`. Left out, the
+pairing skips exactly the command that named a deadline to be paired against,
+which is the one case values.yaml promises will fail the render rather than
+kill the pod early.
+*/}}
+{{- define "obico.isGunicornCommand" -}}
+{{- if regexMatch "^[[:space:]]*([^[:space:]]*/)?gunicorn[0-9]*([^0-9A-Za-z_./-]|$)" . -}}yes
+{{- else if and (regexMatch "(^|[^0-9A-Za-z_])gunicorn[0-9]*([^0-9A-Za-z_./-]|$)" .) (regexMatch "--bind|--workers|--timeout|(^|[[:space:]])-[btw][=[:space:]]*[^[:space:]=]" .) -}}yes
+{{- end -}}
+{{- end }}
+
+{{/*
+Whether any command in mlApi.command starts gunicorn, deferring to
+obico.isGunicornCommand for what that means. A command that hands gunicorn a
+config file of its own does not count: the deadline may well be set in that
+file, and NOTES has nothing to warn about.
+
+A trailing digit is still the program: Debian ships the binary as `gunicorn3`,
+and rejecting that name skipped the pairing check for a real invocation, so a
+140s budget rendered against a 600s deadline — the check answering wrong in the
+one direction it exists to prevent. Widened at all four anchors together, since
+the tail split has to agree with the test that decided there was a tail.
+
+gunicorn as a program name, not as part of a path. A trailing / . _ - or word
+character means this is a file: --access-logfile /var/log/gunicorn/access.log
+and -c gunicorn.conf.py are the spellings gunicorn's own documentation uses,
+and the first is already in this chart's default command with a `-` where a
+path would go. Treating one as the invocation puts everything real before the
+anchor, and the deadline stops being found at all.
+*/}}
+{{/*
+Whether mlApi.command is handed to a shell, which decides whether `&&`, `;`,
+`|` and `&` in it mean anything.
+
+They only mean something to a shell. mlApi.command is a list, and when its
+program is not a shell each element is one argv entry that execve hands over
+untouched — `--access-logformat=%(h)s|%(t)s` is gunicorn's own documented
+syntax for a log format, and the pipe in it is a character in a value, not a
+command boundary. Splitting on it anyway threw away the rest of the command,
+`--timeout` included, and rendered a 140s budget against a 600s deadline.
+
+So the question is answered from the argv rather than from the joined text,
+because joining is exactly what destroys the distinction.
+
+What is looked for is the script flag, not the program. A `-c` is what says
+some element of this argv is a script rather than an argument, and whoever
+ends up handing that script to a shell — `sh`, `bash`, `tini -- sh`,
+`busybox sh`, `dumb-init`, `gosu` — does not change what the string is. Asking
+instead which program sits at the front means keeping a list of every runner
+anyone might put in front of it, and every name missing from that list read a
+poller's deadline past an `&` as gunicorn's own and refused the render over a
+number nothing had set.
+
+Matched as a cluster rather than as the word `-c`, because a shell takes its
+short options joined: `bash -lc` and `sh -ec` run a script exactly as `-c`
+does, and `-cl` puts the letter in the middle rather than at the end.
+
+And required to introduce something multi-word, because `-c` is gunicorn's own
+config-file flag as well as the shell's script flag, and only one of the two
+is followed by a script. `gunicorn -c /etc/g.conf.py` is a path; treating it
+as a script turned metacharacter splitting on for a direct argv command, so
+`--access-logformat=%(h)s|%(t)s` beside it silently dropped the `--timeout`
+that came after — the same command refusing the render without the pipe and
+rendering with it.
+
+Whitespace is the discriminator, and it is safe in both directions. It cannot
+bring back the inventing case: a script able to carry someone else's deadline
+needs a second command in it — a poller past an `&`, a prelude before `&&` —
+and a single word has no room for a command and a flag. So `tini -- sh -c`
+and `busybox sh -c` stay shells. What it can still lose is a config path that
+contains both a space and a metacharacter, and losing leaves the budget as the
+ceiling, which values.yaml promises for every command shape.
+
+That asymmetry is the whole rule. Splitting can only lose a deadline; not
+splitting can invent one, and a fabricated deadline fails the render outright
+on a command that is perfectly valid. Between losing and inventing, lose.
+*/}}
+{{/* Accumulated rather than emitted in the loop: two matching elements would
+     otherwise print "yesyes", and the caller compares against "yes". */}}
+{{- define "obico.mlApiUsesShell" -}}
+{{- $argv := .Values.mlApi.command -}}
+{{- $script := false -}}
+{{- range $i, $arg := $argv -}}
+  {{- if and (regexMatch "^-[a-zA-Z]*c[a-zA-Z]*$" $arg) (lt (add $i 1) (len $argv)) -}}
+    {{- if regexMatch "[[:space:]]" (index $argv (add $i 1)) -}}
+      {{- $script = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $script -}}yes{{- end -}}
+{{- end }}
+
+{{/*
+The command split into the pieces a shell would run, or the whole thing as one
+piece when no shell is involved.
+
+Unquoted, this agrees with the shell by construction: a metacharacter a shell
+would act on is one this cuts at too, so what gets lost is what a shell would
+have put in another command anyway. Often the shell is stricter still —
+`bash -c 'gunicorn --access-logformat=%(h)s|%(t)s ...'` is a syntax error near
+`(`, so that container never starts and there is no deadline to miss.
+
+Quoted is the real gap. The shell hands the whole value to gunicorn, so a
+deadline after it is genuinely in force, and this still cuts at the
+metacharacter inside the quotes and loses it. The pairing check is then
+skipped, leaving the budget as the only ceiling — which is what values.yaml
+promises for every command shape. A quote-aware split is the fix that would
+close that too, and is deliberately not attempted here.
+
+What this costs the operator is bounded by what NOTES claims. It reports that
+no deadline could be READ, never that none was set, so the sentence stays true
+whether the command names one this cannot parse or names none at all. An
+earlier version asserted the stronger thing and needed a second heuristic to
+guess when it was lying; the weaker claim is one the parser can always make
+honestly, and it needed no heuristic at all.
+*/}}
+{{- define "obico.mlApiCommandSegments" -}}
+{{- $joined := join " " .Values.mlApi.command -}}
+{{- if eq (include "obico.mlApiUsesShell" .) "yes" -}}
+{{- join "\x00" (regexSplit "&&|\\|\\||[\n;&|]" $joined -1) -}}
+{{- else -}}
+{{- $joined -}}
+{{- end -}}
+{{- end }}
+
+{{/* Accumulated rather than emitted in the loop, for the same reason
+     obico.mlApiUsesShell is: a command with two gunicorn segments matched
+     twice and printed "yesyes". Only truthiness is read today, so nothing
+     was wrong yet — but the answer is a word, and the first caller to
+     compare it against one would have got a silently false negative. */}}
+{{- define "obico.mlApiRunsGunicorn" -}}
+{{- $runs := false -}}
+{{- range $command := splitList "\x00" (include "obico.mlApiCommandSegments" .) -}}
+  {{- if include "obico.isGunicornCommand" $command -}}
+    {{/* The tail, not the whole command: `bash -c` carries a -c of its own,
+         and a wrapper's flag is not what gunicorn was configured with. */}}
+    {{- $tail := index (regexSplit "gunicorn[0-9]*([^0-9A-Za-z_./-]|$)" $command 2) 1 -}}
+    {{- if not (regexMatch "(^|[^0-9A-Za-z_-])(-c|--config)[ =]" $tail) -}}
+      {{- $runs = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- if $runs -}}yes{{- end -}}
+{{- end }}
+
+
+{{- define "obico.mlApiBootDeadline" -}}
+{{- $deadline := "" -}}
+{{- $answered := false -}}
+{{- range $command := splitList "\x00" (include "obico.mlApiCommandSegments" .) -}}
+  {{/* The first invocation answers, whether or not it names a deadline.
+       Scanning on would credit a later command's flag to this one. */}}
+  {{- if and (not $answered) (include "obico.isGunicornCommand" $command) -}}
+    {{- $answered = true -}}
+    {{- $tail := index (regexSplit "gunicorn[0-9]*([^0-9A-Za-z_./-]|$)" $command 2) 1 -}}
+    {{/* Every occurrence of either spelling, then the last one, because a
+         repeated option wins from the right in argparse and gunicorn is
+         argparse. Taking the first is wrong in both directions at once: it
+         renders `--timeout=120 --timeout=600` against a budget that only
+         covers 120 while the worker really gets 600, and it refuses
+         `--timeout=600 -t 120`, whose real deadline the budget does cover.
+         One pattern rather than one per spelling, because the answer is
+         positional and two searches cannot compare positions — trying the
+         long form first is what made the mixed case answer by spelling
+         instead of by order.
+
+         Quotes are among the separators because argv written as JSON puts
+         them between the flag and its value. */}}
+    {{- $hits := regexFindAll "(--timeout[= \"']+|(^|[[:space:]])-t[= \"']*)0*[0-9]+" $tail -1 -}}
+    {{- if $hits -}}
+      {{- $named := regexFind "[0-9]+$" (last $hits) -}}
+      {{/* Zero is matched above rather than excluded from the pattern, so that
+           it can win as the last word. gunicorn reads 0 as no arbiter deadline
+           at all, so there is nothing to pair against and NOTES has something
+           to warn about — but an earlier number must not be left standing as
+           the answer once a later flag switched the deadline off. */}}
+      {{- if not (regexMatch "^0+$" $named) -}}
+        {{- $deadline = $named -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $deadline -}}
+{{- end }}
+
+{{/*
 Expand the name of the chart.
 */}}
 {{- define "obico.name" -}}

--- a/charts/obico/templates/deployment-ml-api.yaml
+++ b/charts/obico/templates/deployment-ml-api.yaml
@@ -1,5 +1,33 @@
 {{- if .Values.mlApi.enabled }}
 {{- $mlImage := ternary .Values.image.mlApi.gpu .Values.image.mlApi.cpu .Values.mlApi.gpu -}}
+{{- $period := 10 -}}
+{{- $budget := int .Values.mlApi.startupBudgetSeconds -}}
+{{/*
+Explicitly, because `null` in a values file deletes the key rather than setting
+it, and a deleted key never reaches the `minimum` in values.schema.json. `int`
+turns the resulting nil into 0, which would size the probe at a threshold
+Kubernetes silently replaces with its own default — a 30s budget, on exactly
+the slow hardware this value exists for, reported nowhere.
+*/}}
+{{- if lt $budget 1 -}}
+  {{- fail "mlApi.startupBudgetSeconds must be a positive number of seconds. Setting it to null deletes the key rather than restoring the chart default, so remove the override instead of emptying it. If an upgrade reached this without your setting the key at all, re-run it with --reset-then-reuse-values, which layers the chart's defaults under the values you already had." -}}
+{{- end -}}
+{{/*
+Two numbers that only work as a pair. gunicorn kills a worker that has not
+booted within its deadline and respawns it behind a socket that stays open, so
+the startup probe is the only thing that turns an unbootable image into a
+restart; a budget at or below the deadline kills the pod while the first
+worker still has time left.
+*/}}
+{{/*
+atoi, not int: int reads a leading zero as octal, so `--timeout=0200` would
+come back as 128 and clear a 140s budget while gunicorn really allows 200 —
+a misread that fails open. The helper already guarantees digits.
+*/}}
+{{- $deadline := atoi (include "obico.mlApiBootDeadline" .) -}}
+{{- if and (gt $deadline 0) (le $budget $deadline) -}}
+  {{- fail (printf "mlApi.startupBudgetSeconds is %d, which is not above the %ds boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above %d." $budget $deadline $deadline) -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -49,7 +77,7 @@ spec:
             - name: http
               containerPort: 3333
               protocol: TCP
-          # Cheap socket check for liveness; readiness uses /hc/.
+          # Cheap socket check for liveness; startup and readiness use /hc/.
           livenessProbe:
             tcpSocket:
               port: http
@@ -57,11 +85,42 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 6
+          # The boot window belongs here, not on the readiness probe: a
+          # container that has never passed readiness is NotReady from the
+          # start whatever its failureThreshold says, so that number cannot
+          # grant the model time to load. A worker that misses the arbiter
+          # deadline in mlApi.command is killed and respawned forever behind a
+          # listening socket, so without this probe the pod sits NotReady with
+          # a green liveness check and no restarts, and nothing says why.
+          # Crossing the threshold turns that into CrashLoopBackOff, which is
+          # visible.
+          #
+          # Rounded up and then one more, because the failures are fenceposts
+          # rather than intervals. kubelet probes once as soon as the container
+          # is running and only then starts waiting out the period, so N
+          # consecutive failures span (N-1) periods, not N. Take the +1 away
+          # and a budget of 140 buys 130 seconds, which is the kind of gap the
+          # pairing check below is supposed to make impossible: the check
+          # admits any budget above the deadline, so a 130s budget against a
+          # 129s deadline would pass while the container is killed 9 seconds
+          # early.
+          startupProbe:
+            httpGet:
+              path: /hc/
+              port: http
+            periodSeconds: {{ $period }}
+            timeoutSeconds: 5
+            failureThreshold: {{ add (ceil (divf $budget $period) | int) 1 }}
+          # No initialDelaySeconds: the startup probe has already proved /hc/
+          # answers, so delaying the first check only keeps a working pod out
+          # of the Service. failureThreshold governs the one thing readiness
+          # decides, how long a pod that stopped answering keeps taking
+          # traffic, and a single worker holds a stalled inference for the
+          # whole --timeout period.
           readinessProbe:
             httpGet:
               path: /hc/
               port: http
-            initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 6

--- a/charts/obico/tests/deployment_ml_api_test.yaml
+++ b/charts/obico/tests/deployment_ml_api_test.yaml
@@ -38,6 +38,91 @@ tests:
           path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
           value: 1
 
+  # The Jetson recipe the chart README documents: there is no separate switch
+  # for the L4T image, the GPU slot is repointed at it.
+  - it: should run the Jetson image through the gpu slot
+    set:
+      mlApi.gpu: true
+      image.mlApi.gpu.repository: ghcr.io/thespaghettidetective/obico-ml-api-jetson
+      # Spelled out rather than left to the default, so this case stays a
+      # literal transcription of the recipe in the README.
+      image.mlApi.gpu.tag: release
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-ml-api-jetson:release$'
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1
+
+  - it: should not reach the Jetson image while gpu is off
+    set:
+      image.mlApi.gpu.repository: ghcr.io/thespaghettidetective/obico-ml-api-jetson
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-ml-api-cpu:release$'
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+
+  # The published chart pins every image to the commit it was built from, so
+  # this is the shape a user actually starts from when they follow the recipe:
+  # an overridden repository against an inherited pin.
+  - it: should keep a pinned tag when the gpu repository is repointed
+    set:
+      mlApi.gpu: true
+      image.mlApi.gpu.repository: ghcr.io/thespaghettidetective/obico-ml-api-jetson
+      image.mlApi.gpu.tag: sha-abc1234
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '^ghcr\.io/thespaghettidetective/obico-ml-api-jetson:sha-abc1234$'
+
+  # The branch the README singles out as the thing that goes wrong on a Jetson
+  # whose runtime exposes the device without a device plugin. {} would not do
+  # it — Helm coalesces maps key by key, so the chart default survives — and
+  # this is what pins that distinction.
+  - it: should request no accelerator resource when gpuResources is null
+    set:
+      mlApi.gpu: true
+      mlApi.gpuResources: null
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+
+  - it: should keep the default accelerator resource when gpuResources is unset
+    set:
+      mlApi.gpu: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1
+
+  - it: should keep the default accelerator resource for an empty gpuResources
+    set:
+      mlApi.gpu: true
+      mlApi.gpuResources: {}
+    asserts:
+      # The distinction the Jetson recipe rests on, and the one a reader is
+      # most likely to type. Helm merges maps key by key, so an empty one
+      # contributes nothing and the default below it survives — which is why
+      # the recipe says to write null instead. Unset is not the same input as
+      # explicitly empty, and only the latter is what the README warns about.
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+          value: 1
+
+  - it: should drop the accelerator resource for a null gpuResources
+    set:
+      mlApi.gpu: true
+      mlApi.gpuResources: null
+    asserts:
+      # The other half of that sentence: null deletes the key rather than
+      # merging under it, which is what a Jetson runtime exposing the device
+      # without a plugin needs, or the pod sits in Pending forever.
+      - isNull:
+          path: spec.template.spec.containers[0].resources.limits["nvidia.com/gpu"]
+
   - it: should honor a custom gpu resource name
     set:
       mlApi.gpu: true
@@ -62,6 +147,15 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].command
           content: gunicorn
+
+  # The model is loaded at import, inside worker boot. Without a deadline the
+  # arbiter kills the worker at 30s and respawns it forever, so the pod never
+  # goes ready and never crash-loops and nothing says why.
+  - it: should give the worker a boot deadline
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: --timeout=120
 
   - it: should set the ml-api component label
     asserts:
@@ -105,3 +199,688 @@ tests:
       - matchRegex:
           path: metadata.name
           pattern: '^.{1,63}$'
+
+  - it: should give the startup probe more time than the arbiter deadline
+    asserts:
+      # The defaults as a pair: 140s of startup budget against a 120s arbiter
+      # deadline. Asserted together because either number alone says nothing.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.periodSeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.httpGet.path
+          value: /hc/
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: --timeout=120
+
+  - it: should follow a raised deadline when the budget is raised with it
+    set:
+      mlApi.startupBudgetSeconds: 620
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --workers=1
+        - --timeout=600
+        - --access-logfile=-
+        - wsgi
+    asserts:
+      # The knob the chart offers for slow hardware. Before it existed the
+      # threshold was a constant, so this override restarted the pod at 140s
+      # while gunicorn still allowed the worker 600.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 63
+
+  - it: should round the budget up rather than cut a probe
+    set:
+      mlApi.startupBudgetSeconds: 145
+    asserts:
+      # 15 probes to cover 145s, plus the one kubelet spends at t=0.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 16
+
+  - it: should refuse a deadline the startup budget cannot cover
+    set:
+      mlApi.command:
+        - gunicorn
+        - --timeout=600
+        - wsgi
+    asserts:
+      # Raising only the deadline is the mistake worth catching at render
+      # time: the pod would be restarted while the worker was still loading,
+      # and the running cluster would show a crash loop with no cause in it.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read the deadline when the flag and its value are separate words
+    set:
+      mlApi.command:
+        - gunicorn
+        - --timeout
+        - "600"
+        - wsgi
+    asserts:
+      # Both spellings reach production configs, and a check that sees only
+      # one of them passes on exactly the config it was written to catch.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a deadline written in the short form
+    set:
+      mlApi.command:
+        - gunicorn
+        - -t
+        - "600"
+        - wsgi
+    asserts:
+      # Same option, shorter spelling. Missing it leaves the pairing
+      # unenforced for exactly the config that looks unusual.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a deadline written as one short-form word
+    set:
+      mlApi.command:
+        - gunicorn
+        - -t600
+        - wsgi
+    asserts:
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a deadline inside a wrapped command
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout=600 wsgi
+    asserts:
+      # The form this repository writes: docker-compose.yml and the Jetson
+      # symlink workaround both wrap gunicorn in bash -c, and the chart now
+      # documents Jetson. Read element by element there is no deadline here,
+      # and the pairing silently stops holding.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should accept a wrapped command whose deadline the budget covers
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout=120 wsgi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should read past a prelude that carries a deadline of its own
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - wait-for-it --timeout 30 db:5432 && gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout=600 wsgi
+    asserts:
+      # Wrapped commands come with a prelude, and preludes have flags. Read
+      # from the front this finds the 30 that belongs to wait-for-it, decides
+      # the budget covers it, and lets a 600s gunicorn deadline through.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not credit gunicorn with a deadline that belongs to its prelude
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - wait-for-it.sh -t 600 db:5432 -- gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi
+    asserts:
+      # 600, not 30: a value the budget covers cannot tell a misread from a
+      # correct read, because both render the same threshold. Past the budget,
+      # crediting gunicorn with the prelude's flag fails the render instead.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should read a deadline past an option whose value names a gunicorn path
+    set:
+      mlApi.command:
+        - gunicorn
+        - --timeout=600
+        - --access-logfile=/var/log/gunicorn/access.log
+        - wsgi
+    asserts:
+      # A log path under a gunicorn/ directory is the conventional spelling,
+      # and the default command already carries the flag with a `-` where the
+      # path would go. Read as an invocation it puts the real one behind it
+      # and the pairing quietly stops holding.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should accept a covered deadline alongside a gunicorn path
+    set:
+      mlApi.command:
+        - gunicorn
+        - --timeout=120
+        - --access-logfile=/var/log/gunicorn/access.log
+        - wsgi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should read a deadline when the word is mentioned again afterwards
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout=600 wsgi & echo gunicorn is up
+    asserts:
+      # A start-then-say-so line. Anchoring on the last occurrence lands in
+      # the echo, the deadline ends up before the anchor, and the pairing
+      # disappears without a word.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not take a poller's flag on the far side of an operator
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & ./wait-for-it.sh -t 600 localhost:3333
+    asserts:
+      # 600 for the same reason as the prelude case: under the budget, both
+      # readings render alike and the case proves nothing.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should read past a directory argument that names gunicorn
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --chdir
+        - /opt/gunicorn
+        - --timeout=600
+        - wsgi
+    asserts:
+      # The path ends at a space, so it looks like a program name. Splitting
+      # there puts the deadline outside the invocation that set it.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a deadline that comes before a gunicorn-named path
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=600
+        - --chdir
+        - /opt/gunicorn
+        - wsgi
+    asserts:
+      # Deliberately before the path, unlike the case further down. Anchoring
+      # on the last program-looking token lands on /opt/gunicorn, and the
+      # deadline that precedes it is never seen.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a deadline whose value is quoted
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout="600" wsgi
+    asserts:
+      # argv written as JSON puts quotes between the flag and its value, so a
+      # command pasted from that form still names a deadline to pair against.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not read zero as a deadline to pair against
+    set:
+      mlApi.startupBudgetSeconds: 140
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=0
+        - wsgi
+    asserts:
+      # Zero is what disables gunicorn's arbiter, so there is nothing to pair
+      # against and the default budget stands. Reading it as a number would
+      # make `gt $deadline 0` false and skip the pairing silently, which is
+      # the same as having no guard for the one command that needs it.
+      #
+      # The budget still caps the boot. Disabling gunicorn's arbiter does not
+      # buy an unbounded one: the probe restarts the container at the budget
+      # whatever the command asked for, which is a real change from the base,
+      # where no startup probe existed and such a pod stayed NotReady for as
+      # long as the load took. values.yaml states that ceiling.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should not mistake another short flag for the deadline
+    set:
+      mlApi.startupBudgetSeconds: 140
+      mlApi.command:
+        - gunicorn
+        - --threads
+        - "600"
+        - wsgi
+    asserts:
+      # 600 so a misread is visible: -t inside --threads would be read as a
+      # deadline past the budget and fail the render.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should not invent a deadline for a command that has none
+    set:
+      mlApi.command:
+        - python
+        - serve.py
+    asserts:
+      # The override does not have to be gunicorn. Failing here would take the
+      # escape hatch away from anyone running something else.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should not use the readiness probe as a boot budget
+    asserts:
+      # A container that has never passed readiness is NotReady whatever this
+      # number is, so raising it cannot buy boot time. It buys only a longer
+      # window in which a pod that stopped answering keeps taking traffic.
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.failureThreshold
+          value: 6
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.periodSeconds
+          value: 10
+      # Startup gates readiness, so an initial delay here only holds a pod
+      # that has already answered out of the Service.
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe.initialDelaySeconds
+
+  - it: should render the threshold as an integer at any budget
+    set:
+      mlApi.startupBudgetSeconds: 10000000
+    asserts:
+      # ceil returns a float, and Go prints a large one as 1e+06, which the
+      # API server does not accept. Nothing sensible reaches this value; the
+      # point is that the field is an integer whatever it holds.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 1000001
+
+  - it: should still cover the deadline when the budget barely clears it
+    set:
+      mlApi.startupBudgetSeconds: 130
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=129
+        - wsgi
+    asserts:
+      # The narrowest pair the guard admits, which is where a fencepost error
+      # shows. kubelet probes at t=0 and then once per period, so N failures
+      # span (N-1) periods: 14 buys 130s and covers the 129s deadline, 13 would
+      # buy 120 and kill the container nine seconds before gunicorn gives up on
+      # the worker — the exact outcome the guard promises cannot happen.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 14
+
+  - it: should read the deadline from a wrapped command that carries no bind flag
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - exec gunicorn --timeout=600 wsgi
+    asserts:
+      # `exec` is how the server ends up as PID 1, and the deadline flag is as
+      # much proof of an invocation as --bind. Qualifying only on bind/workers
+      # skips the command that named a deadline at all, which is the one case
+      # values.yaml promises fails the render instead of killing the pod early.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read the deadline from a versioned gunicorn binary name
+    set:
+      mlApi.command:
+        - gunicorn3
+        - --bind=0.0.0.0:3333
+        - --timeout=600
+        - wsgi
+    asserts:
+      # Debian names the binary gunicorn3. Anchored on the bare name only, this
+      # is not read as an invocation at all, so the pairing check is skipped
+      # and a 140s budget renders against a 600s deadline — the check failing
+      # open in exactly the case it exists for.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should still not read a gunicorn path as the program
+    set:
+      mlApi.startupBudgetSeconds: 140
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --access-logfile=/var/log/gunicorn/access.log
+        - --timeout=600
+        - wsgi
+    asserts:
+      # The widened anchor must not start matching paths. /var/log/gunicorn/
+      # ends in a slash, which the trailing class still excludes, so the
+      # deadline is read from the real invocation rather than from whatever
+      # follows the log path.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not treat a pipe inside a flag value as a command boundary
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --access-logformat=%(h)s|%(t)s
+        - --timeout=600
+        - wsgi
+    asserts:
+      # gunicorn's own documented log-format syntax, and no shell anywhere in
+      # the command — execve hands each argv entry over untouched, so the pipe
+      # is a character in a value. Cutting there threw away everything after
+      # it, --timeout included, and rendered the default budget against a 600s
+      # deadline.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not treat a semicolon inside a flag value as a command boundary
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --access-logformat=a;b
+        - --timeout=600
+        - wsgi
+    asserts:
+      # The same hole through a different metacharacter, pinned separately so
+      # narrowing the split to one of them cannot pass for fixing the class.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not read gunicorn's own config flag as a shell script flag
+    set:
+      mlApi.command:
+        - gunicorn
+        - -c
+        - /etc/g.conf.py
+        - --access-logformat=%(h)s|%(t)s
+        - --timeout=600
+        - wsgi
+    asserts:
+      # `-c` is gunicorn's config-file flag as well as the shell's script flag,
+      # and only one of them is followed by a script. Counting this one as a
+      # script turns metacharacter splitting on for a direct argv command, and
+      # the pipe in the log format then cuts the `--timeout` away — the same
+      # command refusing without the pipe and rendering with it. What separates
+      # the two is that a script is multi-word and a config path is not.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not invent a deadline behind an init wrapper
+    set:
+      mlApi.command:
+        - /sbin/tini
+        - --
+        - sh
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & ./poll.sh -t 600 localhost
+    asserts:
+      # gunicorn is started bare; the 600 belongs to the poller past an
+      # unquoted `&`. Deciding shell-or-not by the program at the front makes
+      # `tini --` — an ordinary container entrypoint — read as a direct argv,
+      # which keeps the whole line in one segment and hands the poller's number
+      # to gunicorn. That refuses the render over a deadline nothing set, on a
+      # command that rendered fine before this chart had a probe at all.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should not invent a deadline behind a multi-call binary
+    set:
+      mlApi.command:
+        - busybox
+        - sh
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & ./poll.sh -t 600 localhost
+    asserts:
+      # The same shape with the shell reached through busybox rather than a
+      # prefix runner. Pinned separately because a program list could learn
+      # `tini` and still not know this one — the point is that no list is
+      # consulted at all.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should still read shell operators when a shell runs the command
+    set:
+      mlApi.command:
+        - /usr/bin/env
+        - FOO=1
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 wsgi & ./wait-for-it.sh -t 600 localhost:3333
+    asserts:
+      # The other half of the same decision, and the discriminating one: here a
+      # shell really does run the line, so `&` really is a boundary and the
+      # poller's -t belongs to the poller. Read as one argv instead, the tail
+      # after gunicorn swallows -t 600 and the render is refused over a
+      # deadline gunicorn was never given.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should read a shell whose script flag is clustered with another
+    set:
+      mlApi.command:
+        - bash
+        - -lc
+        - gunicorn --timeout=600 wsgi & ./wait-for-it.sh -t 30 localhost:3333
+    asserts:
+      # A shell takes its short options joined, and `-lc` runs a script exactly
+      # as `-c` does. Looked for as the word `-c`, this wrapper falls to the
+      # argv path, the whole line becomes one segment, and the poller's -t 30
+      # wins as the last deadline — hiding the real 600 behind a number
+      # gunicorn was never given.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read a shell whose script flag sits mid-cluster
+    set:
+      mlApi.command:
+        - bash
+        - -cl
+        - gunicorn --timeout=600 wsgi & ./wait-for-it.sh -t 30 localhost:3333
+    asserts:
+      # The same cluster written the other way round. Pinned separately because
+      # anchoring the letter at the end of the cluster passes the case above
+      # while still missing this one.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read the deadline behind an env prefix carrying flags
+    set:
+      mlApi.command:
+        - env
+        - -i
+        - bash
+        - -c
+        - gunicorn --timeout=600 wsgi & ./wait-for-it.sh -t 30 localhost:3333
+    asserts:
+      # Whatever stands between the container and the shell — `env` with flags
+      # of its own here — the script is still a script. Nothing walks the front
+      # of the argv looking for a known program, so there is no list for this
+      # spelling to be missing from.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should refuse a budget that only matches the deadline
+    set:
+      mlApi.startupBudgetSeconds: 120
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=120
+        - wsgi
+    asserts:
+      # The transition point of the guard, and the whole of what `le` decides
+      # over `lt`. Equal is not above: kubelet would kill the container at the
+      # same instant the arbiter deadline expires, which is the outcome the
+      # comment beside the guard promises cannot happen. Both values.yaml and
+      # the error message state the contract as "above", so the boundary is
+      # the sentence being enforced, not an edge case beside it.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 120, which is not above the 120s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 120.
+
+  - it: should take the last of two deadline flags rather than the first
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=120
+        - --timeout=600
+        - wsgi
+    asserts:
+      # argparse lets a repeated option win from the right, so the worker
+      # really gets 600. Answering with the first leaves the budget covering
+      # 120 and the pod killed at 140 while gunicorn still allows 600 — the
+      # guard approving exactly what it exists to refuse.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should let a trailing zero switch the deadline off
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=600
+        - --timeout=0
+        - wsgi
+    asserts:
+      # The last word disables gunicorn's arbiter, so there is no deadline to
+      # pair against and this renders. Leaving the earlier 600 standing as the
+      # answer refuses a wholly valid command — a hard install failure, which
+      # is the louder way to be wrong.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should take a short-form deadline that comes last
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=600
+        - -t
+        - "120"
+        - wsgi
+    asserts:
+      # Effective deadline is 120, which the default budget covers, so this
+      # renders. Searching the long spelling first answers by spelling rather
+      # than by position and refuses it.
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.failureThreshold
+          value: 15
+
+  - it: should take a long-form deadline that comes last
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - -t
+        - "120"
+        - --timeout=600
+        - wsgi
+    asserts:
+      # The mirror of the case above, and the one that used to come out right
+      # by luck: the long form was searched first and happened to also be last.
+      # Pinned so the answer stays positional rather than coincidental.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should refuse a mention that carries the deadline flag
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - echo about to start gunicorn -t 600 && python serve.py
+    asserts:
+      # Deciding invocation from a flag cannot tell this from the real thing,
+      # so the 600 is read as a boot deadline and the render is refused. Pinned
+      # because it is the expensive half of that trade: a mention carrying
+      # -b or -w only prints a NOTES line, while this one blocks the install
+      # naming a deadline no process here has.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should not read a leading-zero deadline as octal
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=0200
+        - wsgi
+    asserts:
+      # `int` parses 0200 as octal 128, which clears the 140s budget while
+      # gunicorn really allows 200 — a misread that fails open. atoi reads it
+      # as 200 and the pair is refused.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 200s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 200.
+
+  - it: should read the deadline from a wrapped command with attached values
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn -b0.0.0.0:3333 -w1 -t600 wsgi
+    asserts:
+      # argparse takes a short option's value attached or separated, and the
+      # attached form is the terser habit. Requiring a separator on -b/-w while
+      # the deadline reader accepts -t600 attached leaves one half of the same
+      # check unable to read what the other half already does.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should read the deadline from a wrapped command using short flags
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn -b 0.0.0.0:3333 -w 1 -t 600 wsgi
+    asserts:
+      # `-b` and `-w` are what fit on a one-line `bash -c`, and gunicorn
+      # documents them alongside the long spellings. Recognised only by the
+      # long ones, this command reads as a mention rather than an invocation,
+      # and the 600s deadline is never paired against the 140s budget.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds is 140, which is not above the 600s boot deadline in mlApi.command. Kubernetes would restart the container while gunicorn still allows the worker to finish loading the model. Raise startupBudgetSeconds above 600.
+
+  - it: should refuse a startup budget that was deleted rather than set
+    set:
+      mlApi.startupBudgetSeconds: null
+      mlApi.command:
+        - python
+        - serve.py
+    asserts:
+      # null removes the key instead of restoring the default, so the schema
+      # minimum never sees it and `int` yields 0. A non-gunicorn command has no
+      # deadline to pair against, so nothing else would catch it: the probe
+      # would render a threshold Kubernetes replaces with its own default of 3,
+      # handing the slowest hardware the shortest budget without a word.
+      - failedTemplate:
+          errorMessage: mlApi.startupBudgetSeconds must be a positive number of seconds. Setting it to null deletes the key rather than restoring the chart default, so remove the override instead of emptying it. If an upgrade reached this without your setting the key at all, re-run it with --reset-then-reuse-values, which layers the chart's defaults under the values you already had.

--- a/charts/obico/tests/notes_test.yaml
+++ b/charts/obico/tests/notes_test.yaml
@@ -32,3 +32,342 @@ tests:
           pattern: 'python manage\.py createsuperuser'
       - notMatchRegexRaw:
           pattern: 'signing up in the web UI'
+
+  - it: should stay quiet about the boot deadline when the default command keeps it
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn when an mlApi.command override drops the boot deadline
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --workers=1
+        - wsgi
+    asserts:
+      # Without a deadline gunicorn kills the worker after 30s, which is less
+      # than the model load takes, and the container restarts forever. The
+      # override is the only way to reach that state, so this is where it is said.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should stay quiet when ml-api is not deployed at all
+    set:
+      mlApi.enabled: false
+      mlApi.command:
+        - gunicorn
+        - wsgi
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn about a gunicorn flag for a command that is not gunicorn
+    set:
+      mlApi.command:
+        - python
+        - serve.py
+    asserts:
+      # The deployment template allows this and has its own case for it. A
+      # warning here would name a deadline the process does not have and a
+      # failure mode it cannot hit.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn about a deadline written in the short form
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - -t
+        - "120"
+        - wsgi
+    asserts:
+      # gunicorn documents -t and --timeout as the same option. Warning here
+      # tells someone their working config is broken.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn about a deadline set inside a wrapped command
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout 120 wsgi
+    asserts:
+      # Same shape docker-compose.yml ships. Warning here tells someone whose
+      # command sets a deadline that they set none.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should still warn about a wrapped command that sets no deadline
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi
+    asserts:
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should report a quoted deadline as unread rather than unset
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - exec gunicorn --bind=0.0.0.0:3333 --access-logformat="%(h)s|%(t)s" --timeout=600 wsgi
+    asserts:
+      # The quote makes the pipe an argument rather than a pipeline, so the
+      # shell really does hand gunicorn a 600s deadline that the split cuts away
+      # and never sees. The warning still belongs here — what it must not do is
+      # claim none was set, which would send this operator to add the flag
+      # already in their own command. Reporting what was read keeps it true.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should still warn when a quote sits beside a poller's deadline
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & ./wait-for-it.sh -t 600 'localhost:3333'
+    asserts:
+      # gunicorn is started bare here and the 600 belongs to the poller past an
+      # unquoted `&`, so the warning is true. A rule that went quiet whenever a
+      # quote and a deadline both appeared somewhere in the command silenced it
+      # on the strength of quotes around a hostname.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should stay quiet about a wrapped invocation carrying no flags at all
+    set:
+      mlApi.command:
+        - sh
+        - -c
+        - gunicorn wsgi
+    asserts:
+      # A known silence, pinned so it stays a decision rather than becoming a
+      # surprise. Inside a wrapper the word gunicorn can be a mention, so a
+      # flag only an invocation carries is required — and this command has
+      # none, so it reads as a mention and gets no warning even though the
+      # worker really does boot on the 30s default. The budget still caps it,
+      # which is why the silence is affordable; the suite pins every other
+      # shape this heuristic decides, and this one was the gap.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn about a versioned binary name carrying no flags
+    set:
+      mlApi.command:
+        - gunicorn3
+        - wsgi
+    asserts:
+      # Pins the program-position anchors specifically. Every other versioned
+      # binary case passes --bind, which lets the wrapper branch answer even
+      # if the position branch is narrowed back — so those tests cover the
+      # name without covering where it sits. With no gunicorn-shaped flag at
+      # all, only position can decide, and the warning is the only thing that
+      # notices.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn about a versioned gunicorn binary name
+    set:
+      mlApi.command:
+        - gunicorn3
+        - --bind=0.0.0.0:3333
+        - wsgi
+    asserts:
+      # Pins the fourth anchor. The name is recognised on this path too, so the
+      # tail split has something to split on: leave this one un-widened while
+      # the recognition test says yes and regexSplit returns a single element,
+      # which makes `index ... 1` abort the whole render rather than merely
+      # skip a warning. The deadline-side tests cannot catch that — they never
+      # reach this helper.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn about a wrapped command whose short flags carry attached values
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn -b0.0.0.0:3333 -w1 wsgi
+    asserts:
+      # The same invocation with the separators dropped, which argparse accepts
+      # and which is the terser habit. Missed here, the command that has no
+      # deadline at all is the one that stops being told so.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn about a wrapped command written with short flags
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn -b 0.0.0.0:3333 -w 1 wsgi
+    asserts:
+      # The same command in the spelling gunicorn documents beside the long
+      # one. Qualified on `--bind`/`--workers` alone, this reads as a bare
+      # mention rather than an invocation, and the command that most needs the
+      # warning is the one that stops getting it.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn when only the prelude carries a deadline
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - wait-for-it.sh -t 30 db:5432 -- gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi
+    asserts:
+      # The state this warning exists for: gunicorn started bare. Reading the
+      # whole line finds wait-for-it's -t and stays silent about it.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn when the deadline sits beside a gunicorn path
+    set:
+      mlApi.command:
+        - gunicorn
+        - --timeout=120
+        - --access-logfile=/var/log/gunicorn/access.log
+        - wsgi
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should still warn when only the gunicorn path is there
+    set:
+      mlApi.command:
+        - gunicorn
+        - --access-logfile=/var/log/gunicorn/access.log
+        - wsgi
+    asserts:
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn when the word is mentioned again after the deadline
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout=120 wsgi & echo gunicorn is up
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn when the only deadline belongs to a poller
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & ./wait-for-it.sh -t 30 localhost:3333
+    asserts:
+      # gunicorn was started bare. The -t after the & is the poller's.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn when the deadline comes before a gunicorn-named path
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --timeout=120
+        - --chdir
+        - /opt/gunicorn
+        - wsgi
+    asserts:
+      # Reading from the last program-looking token loses everything before
+      # /opt/gunicorn, so a command that sets a deadline is told it sets none.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not call a mention of gunicorn an invocation
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - echo starting gunicorn now && python serve.py
+    asserts:
+      # Nothing here starts gunicorn, so there is no arbiter deadline to be
+      # missing and nothing to warn about.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not judge a command whose deadline may be in a config file
+    set:
+      mlApi.command:
+        - gunicorn
+        - -c
+        - gunicorn.conf.py
+        - wsgi
+    asserts:
+      # `timeout = 120` in gunicorn.conf.py is a deliberate way to set this.
+      # The chart cannot read that file, so calling the deadline missing sends
+      # someone to add a flag they moved on purpose.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not be fooled by the -c that belongs to the wrapper
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi
+    asserts:
+      # `bash -c` is not gunicorn's config flag. Reading the whole command
+      # instead of gunicorn's own arguments exempts every wrapped command.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not judge a command configured through the long flag either
+    set:
+      mlApi.command:
+        - gunicorn
+        - --config
+        - /etc/gunicorn.py
+        - wsgi
+    asserts:
+      # gunicorn documents -c and --config as the same option, and a check
+      # that knows one of them judges a command it cannot read.
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not borrow a deadline from a second invocation
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 wsgi & gunicorn --bind 0.0.0.0:3334 --workers 1 --timeout 600 wsgi
+    asserts:
+      # The first command starts gunicorn with no deadline, and that is the
+      # answer. Scanning on until a deadline turns up credits the second
+      # command's flag to the first, and the warning disappears.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should warn when the deadline is written as zero
+    set:
+      mlApi.command:
+        - gunicorn
+        - --bind=0.0.0.0:3333
+        - --workers=1
+        - --timeout=0
+        - wsgi
+    asserts:
+      # gunicorn reads 0 as no arbiter deadline at all, so this command has
+      # none. Reading it as a deadline of zero also switches off the pairing
+      # check below, which is the one value that must not be able to do that.
+      - matchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'
+
+  - it: should not warn when the deadline value is quoted
+    set:
+      mlApi.command:
+        - bash
+        - -c
+        - gunicorn --bind 0.0.0.0:3333 --workers 1 --timeout="120" wsgi
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'no timeout could be read from mlApi\.command'

--- a/charts/obico/values.schema.json
+++ b/charts/obico/values.schema.json
@@ -217,6 +217,11 @@
           },
           "description": "Accelerator resources merged into the ml-api container limits when gpu is true"
         },
+        "startupBudgetSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Seconds the ml-api container gets to answer /hc/ before a restart"
+        },
         "replicaCount": {
           "type": "integer",
           "minimum": 0,

--- a/charts/obico/values.yaml
+++ b/charts/obico/values.yaml
@@ -7,8 +7,8 @@
 # (.github/workflows/build-images.yaml) and published to GHCR under the
 # repository owner's namespace (ghcr.io/thespaghettidetective/* upstream). Each
 # tag defaults to the "release" moving tag the workflow publishes on the release
-# branch; pin a specific tag (a CalVer like 2026.7.1 or sha-<short>) for
-# reproducibility.
+# branch; pin an immutable tag for reproducibility: `<calver>-g<short>` (e.g.
+# `2026.7.11-g49c0bc70`) or the terse `sha-<short>`.
 image:
   # -- Web application image (Django + Celery)
   web:
@@ -16,9 +16,10 @@ image:
     pullPolicy: IfNotPresent
     # -- Overrides the image tag whose default is the "release" moving tag
     tag: ""
-  # -- ML inference API images. Two variants are published from the same source:
-  # a slim CPU-only image (default) and a CUDA image for GPU inference.
-  # mlApi.gpu selects which one runs; configure each variant independently.
+  # -- ML inference API images. The chart runs one of two variants built from
+  # the same source: a slim CPU-only image (default) and a CUDA image for GPU
+  # inference. mlApi.gpu selects which one runs; configure each variant
+  # independently.
   mlApi:
     pullPolicy: IfNotPresent
     # -- CPU-only inference image (slim). Used when mlApi.gpu is false.
@@ -179,13 +180,46 @@ mlApi:
     nvidia.com/gpu: 1
   # -- Number of ml-api replicas
   replicaCount: 1
-  # -- Command for the gunicorn inference server
+  # -- Command for the gunicorn inference server. The `--timeout` flag is
+  # load-bearing: the model is loaded at import, so it happens inside worker
+  # boot, and the default 30s arbiter deadline would kill the worker and
+  # respawn it forever on a slower node — the pod would never go ready and
+  # never crash-loop, so nothing would say why. Note it is not boot-only: the
+  # same value bounds request handling, and with a single worker a stalled
+  # inference holds that worker for the whole period before the arbiter
+  # recycles it. Readiness drops the pod out of the Service after 60s of that,
+  # which is the only part probes can help with; the boot case belongs to
+  # startupBudgetSeconds, which has to stay above whatever is set here. Not
+  # solved with gunicorn `--preload`, which would load the model in the arbiter
+  # and take it out from under this deadline: server.py calls load_net at
+  # import, and on the GPU images that initialises CUDA or opens a
+  # CUDAExecutionProvider session, and `--preload` still forks the worker
+  # afterwards.
   command:
     - gunicorn
     - --bind=0.0.0.0:3333
     - --workers=1
+    - --timeout=120
     - --access-logfile=-
     - wsgi
+  # -- Seconds the container gets to answer /hc/ before Kubernetes restarts
+  # it. Has to stay above the `--timeout` in command, or the pod is killed
+  # while the first worker still has time left to finish loading; rendering
+  # fails when it is not. Raise both together on hardware where the model
+  # takes longer than this to load, and note that raising this alone only
+  # delays the restart of an image that cannot boot at all.
+  # This is the boot ceiling for every shape of command, including the ones no
+  # deadline can be read out of: a `gunicorn.conf.py` passed with `-c`, an
+  # explicit `--timeout=0`, or a command that is not gunicorn at all. Before
+  # this chart had a startup probe such a container stayed NotReady for as long
+  # as the load took, so long as it had opened the port — the tcpSocket
+  # liveness check still ended one that never bound at all. Now the budget ends
+  # it either way, and the render-time pairing check cannot warn about a
+  # deadline it cannot see. Raise this to whatever the slowest boot needs.
+  # Spent in whole probe periods of 10s, rounded up, so a value below 10 still
+  # buys one period and one below the deadline is refused rather than rounded
+  # into looking sufficient.
+  startupBudgetSeconds: 140
   # -- Security context for the ml-api container.
   # Left empty (image default = root) because the upstream CUDA-based ml-api
   # image is not validated to run unprivileged (model cache and runtime expect


### PR DESCRIPTION
Chart side of #1148, split out so the chart review does not have to happen inside the images PR. Everything here renders and tests against master. The tie to the images PR is documentation only, but it is wider than one recipe: the README and the chart changelog describe the arm64 platforms, the immutable tag scheme and the Jetson image in present tense, and those exist once #1148 merges and a release runs. So the merge order is #1148 first, then this one; the text is written to be true in the merged state rather than hedged into future tense.

## What changes

Every ml-api pod gains a startup probe on `/hc/`. Without one, a pod whose model load runs past the gunicorn deadline sits not-ready behind a liveness check that keeps passing, never restarts, and says nothing about why. Now it crash-loops, which is at least visible. The readiness probe drops its initial delay, since the startup probe covers boot now.

`mlApi.startupBudgetSeconds` (default 140) sets how long that probe waits, and rendering fails when it is not above the deadline in `mlApi.command`, since those two numbers only work as a pair. The deadline is read in every spelling gunicorn accepts, including wrapped `bash -c` commands, and a command that names a config file instead is left alone.

The README documents how to point the GPU image slot at the published arm64 and Jetson images, with the caveats each carries.

## Breaking change

`helm upgrade` now fails at render time for an override where `mlApi.command` carries a `--timeout` at or above `startupBudgetSeconds`. The error message states the exact value to raise. This is deliberate: the alternative is Kubernetes restarting the pod while gunicorn still allows its worker time to finish loading the model.

## Notes for review

This PR shows no CI checks: the pre-merge workflow is part of #1148 and not on master yet. Lint, the 204 chart unit tests and generated-README freshness all ran locally.




