### PR TITLE
Fall back to default syndicate when site has no syndicate link

### DIFF
--- a/backend/app/tests.py
+++ b/backend/app/tests.py
@@ -1,5 +1,5 @@
 from django.contrib.sites.models import Site
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from unittest.mock import ANY, patch, PropertyMock
 from requests import Response
@@ -156,3 +156,15 @@ class PrinterEventTestCase(TestCase):
             }
 
             self.assertEqual(get_rotated_pic_url(self.printer), img_url)
+
+
+@override_settings(STATICFILES_STORAGE='django.contrib.staticfiles.storage.StaticFilesStorage')
+class UnlinkedSitePageRenderTestCase(TestCase):
+
+    def test_login_page_renders_when_site_has_no_syndicate(self):
+        site = Site.objects.create(domain='unlinked.test', name='unlinked.test')
+        site.syndicates.clear()
+
+        response = self.client.get('/accounts/login/', HTTP_HOST='unlinked.test')
+
+        self.assertEqual(response.status_code, 200)

--- a/backend/lib/syndicate.py
+++ b/backend/lib/syndicate.py
@@ -13,8 +13,9 @@ def syndicate_from_request(request):
     if syndicate_header:
       return Syndicate.objects.get(name=syndicate_header)
 
-    # 3. site syndicate is the default.
-    return get_current_site(request).syndicates.first()
+    # 3. site syndicate is the default. Fall back to the default syndicate if the site is not linked to any.
+    return get_current_site(request).syndicates.first() or \
+        Syndicate.objects.order_by('id').first()
 
 
 def settings_for_syndicate(syndicate_name):

--- a/backend/lib/tests.py
+++ b/backend/lib/tests.py
@@ -1,9 +1,13 @@
-from django.test import TransactionTestCase
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.sites.models import Site
+from django.test import RequestFactory, TestCase, TransactionTestCase
 from unittest.mock import patch
 
 
 from app.models import User, HeaterTracker, Printer, Print
+from app.models.syndicate_models import Syndicate
 from .heater_trackers import process_heater_temps
+from .syndicate import syndicate_from_request
 
 
 class HeaterTrackerTestCase(TransactionTestCase):
@@ -225,3 +229,33 @@ class HeaterTrackerTestCase(TransactionTestCase):
 
         self.assertEqual(print.PrintHeaterTarget_set.first().name, 'h0')
         self.assertEqual(print.PrintHeaterTarget_set.first().target, 60.0)
+
+
+class SyndicateFromRequestTestCase(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.default_syndicate = Syndicate.objects.order_by('id').first()
+
+    def anonymous_request(self, host):
+        request = self.factory.get('/', HTTP_HOST=host)
+        request.user = AnonymousUser()
+        return request
+
+    def test_linked_site_resolves_its_own_syndicate(self):
+        other_syndicate = Syndicate.objects.create(name='other')
+        site = Site.objects.create(domain='linked.test', name='linked.test')
+        site.syndicates.set([other_syndicate])
+
+        self.assertEqual(
+            syndicate_from_request(self.anonymous_request('linked.test')),
+            other_syndicate)
+
+    def test_unlinked_site_falls_back_to_default_syndicate(self):
+        site = Site.objects.create(domain='unlinked.test', name='unlinked.test')
+        site.syndicates.clear()
+
+        self.assertIsNotNone(self.default_syndicate)
+        self.assertEqual(
+            syndicate_from_request(self.anonymous_request('unlinked.test')),
+            self.default_syndicate)


### PR DESCRIPTION
# Fall back to default syndicate when site has no syndicate link

Fixes #1154 

## What changed

One line in `syndicate_from_request()` in `backend/lib/syndicate.py`. The anonymous-request fallback was:

```python
return get_current_site(request).syndicates.first()
```

If the site isn't linked to any syndicate, that returns None and the context processor crashes on `.name`, which 500s every anonymous page on that host (details in the issue). Now it falls back to the default syndicate (first by id) instead - the same one the `add_site_to_default_syndicate` signal picks when it links newly created sites. So new sites and existing unlinked ones end up treated the same way.

## Why

I hit this while sorting out #1152 on my own server. Keeping exactly one site linked to the syndicate is what makes media URLs come out with a predictable host, but before this fix, the unlinked hosts couldn't serve a login page anymore. This lets both work at once. It's a small defensive fix, nothing more.

## How I tested it

- Tests for `syndicate_from_request()` in `backend/lib/tests.py`: a linked site still resolves its own syndicate, an unlinked one resolves the default instead of None.
- A test in `backend/app/tests.py` that the login page over an unlinked site's host renders 200 instead of crashing. That test class overrides `STATICFILES_STORAGE` to the plain storage, since the manifest storage wants a `collectstatic` that hasn't run in the test container.
- All three fail without the fix, pass with it.
- Ran the backend suite per CONTRIBUTING (`docker compose -f docker-compose.yml -f docker-compose-dev.yml run --rm web python manage.py test`). The 3 new tests pass. The suite also shows 33 errors in `HeaterTrackerTestCase` that are identical on a clean master checkout - looks like a test isolation thing (it's a TransactionTestCase, and the post-test flush deletes the default syndicate that `User.syndicate` defaults to). Not caused or fixed here.
- Been running it on my production server (same one as #1152) with one linked site and two unlinked: login and admin work over the unlinked hosts, the linked host behaves exactly as before.

## Notes

No migrations, no config changes. Only requests that used to crash behave differently - anything that resolved a syndicate before resolves the same one now.

In case it comes up: this doesn't remove a way to disable a host. Unlinking never actually blocked access (logged-in users kept working the whole time), and deleting the Site record just gets you a different 500. If you want to stop serving a host, that's a reverse proxy or DNS job.